### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ chacha20poly1305 = "0.7"
 generic-array = { version = "0.14", default-features = false }
 digest = "0.9"
 hkdf = "0.10"
-rand = { version = "0.7", default-features = false }
-p256 = { version = "0.6", default-features = false, features = ["arithmetic", "zeroize"], optional = true}
+rand = { version = "0.8", default-features = false, features = ["std_rng"] }
+p256 = { version = "0.7", default-features = false, features = ["arithmetic", "zeroize"], optional = true}
 sha2 = { version = "0.9", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.3", default-features = false }
 zeroize = { version = "1.2", default-features = false, features = ["zeroize_derive"] }
 
 [dependencies.x25519-dalek]
-version = "0.6"
+version = "1.1"
 default-features = false
 features = ["u64_backend"]
 optional = true
@@ -49,7 +49,7 @@ hex = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-rand = { version = "0.7", default-features = false, features = ["getrandom"] }
+rand = { version = "0.8", default-features = false, features = ["std_rng", "getrandom"] }
 
 [[example]]
 name = "client_server"


### PR DESCRIPTION
Note that crate p256 changed its API.
`p256::EncodedPoint.x()` now returns `Option<_>`, so I moved it to a function that could error out.