### PR TITLE
Fix cargo audit warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ serde_impls = ["serde", "generic-array/serde"]
 std = []
 
 [dependencies]
-aead = "0.3"
-aes-gcm = "0.8"
+aead = "0.4"
+aes-gcm = "0.9"
 byteorder = { version = "1.4", default-features = false }
-chacha20poly1305 = "0.7"
+chacha20poly1305 = "0.8"
 generic-array = { version = "0.14", default-features = false }
 digest = "0.9"
 hkdf = "0.10"

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use core::{default::Default, marker::PhantomData, u8};
 
-use aead::{AeadInPlace as BaseAead, NewAead as BaseNewAead};
+use aead::{AeadCore, AeadInPlace as BaseAead, NewAead as BaseNewAead};
 use byteorder::{BigEndian, ByteOrder};
 use generic_array::GenericArray;
 use hkdf::Hkdf;
@@ -18,7 +18,7 @@ use zeroize::Zeroize;
 /// Represents authenticated encryption functionality
 pub trait Aead {
     /// The underlying AEAD implementation
-    type AeadImpl: BaseAead + BaseNewAead + Clone;
+    type AeadImpl: AeadCore + BaseAead + BaseNewAead + Clone;
 
     /// The algorithm identifier for an AEAD implementation
     const AEAD_ID: u16;
@@ -26,7 +26,7 @@ pub trait Aead {
 
 // A nonce is a bytestring you only use for encryption once
 pub(crate) struct AeadNonce<A: Aead>(
-    pub(crate) GenericArray<u8, <A::AeadImpl as BaseAead>::NonceSize>,
+    pub(crate) GenericArray<u8, <A::AeadImpl as AeadCore>::NonceSize>,
 );
 
 // We need this for ease of testing
@@ -40,7 +40,7 @@ impl<A: Aead> Clone for AeadNonce<A> {
 // We use this to get an empty buffer we can read nonce material into
 impl<A: Aead> Default for AeadNonce<A> {
     fn default() -> AeadNonce<A> {
-        AeadNonce(GenericArray::<u8, <A::AeadImpl as BaseAead>::NonceSize>::default())
+        AeadNonce(GenericArray::<u8, <A::AeadImpl as AeadCore>::NonceSize>::default())
     }
 }
 
@@ -119,10 +119,10 @@ fn mix_nonce<A: Aead>(base_nonce: &AeadNonce<A>, seq: &Seq) -> AeadNonce<A> {
 }
 
 /// An authenticated encryption tag
-pub struct AeadTag<A: Aead>(GenericArray<u8, <A::AeadImpl as BaseAead>::TagSize>);
+pub struct AeadTag<A: Aead>(GenericArray<u8, <A::AeadImpl as AeadCore>::TagSize>);
 
 impl<A: Aead> Serializable for AeadTag<A> {
-    type OutputSize = <A::AeadImpl as BaseAead>::TagSize;
+    type OutputSize = <A::AeadImpl as AeadCore>::TagSize;
 
     fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
         self.0.clone()
@@ -383,7 +383,7 @@ mod test {
     use super::{Aead, AeadTag, AesGcm128, AesGcm256, ChaCha20Poly1305, ExportOnlyAead, Seq};
     use crate::{kdf::HkdfSha256, kex::Deserializable, test_util::gen_ctx_simple_pair, HpkeError};
 
-    use aead::AeadInPlace as BaseAead;
+    use aead::AeadCore;
     use generic_array::GenericArray;
 
     /// Tests that encryption context secret export does not change behavior based on the
@@ -454,7 +454,7 @@ mod test {
                 let mut ciphertext = *b"back hand";
                 let aad = b"with my prayers";
                 // The contents of the tag doesn't matter. This will panic before the take is read
-                type TagSize = <<A as Aead>::AeadImpl as BaseAead>::TagSize;
+                type TagSize = <<A as Aead>::AeadImpl as AeadCore>::TagSize;
                 let tag = AeadTag(GenericArray::<u8, TagSize>::default());
 
                 let _ = receiver_ctx.open(&mut ciphertext[..], aad, &tag);

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use core::{default::Default, marker::PhantomData, u8};
 
-use aead::{AeadCore, AeadInPlace as BaseAead, NewAead as BaseNewAead};
+use aead::{AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, NewAead as BaseNewAead};
 use byteorder::{BigEndian, ByteOrder};
 use generic_array::GenericArray;
 use hkdf::Hkdf;
@@ -18,7 +18,7 @@ use zeroize::Zeroize;
 /// Represents authenticated encryption functionality
 pub trait Aead {
     /// The underlying AEAD implementation
-    type AeadImpl: AeadCore + BaseAead + BaseNewAead + Clone;
+    type AeadImpl: BaseAeadCore + BaseAeadInPlace + BaseNewAead + Clone;
 
     /// The algorithm identifier for an AEAD implementation
     const AEAD_ID: u16;
@@ -26,7 +26,7 @@ pub trait Aead {
 
 // A nonce is a bytestring you only use for encryption once
 pub(crate) struct AeadNonce<A: Aead>(
-    pub(crate) GenericArray<u8, <A::AeadImpl as AeadCore>::NonceSize>,
+    pub(crate) GenericArray<u8, <A::AeadImpl as BaseAeadCore>::NonceSize>,
 );
 
 // We need this for ease of testing
@@ -40,7 +40,7 @@ impl<A: Aead> Clone for AeadNonce<A> {
 // We use this to get an empty buffer we can read nonce material into
 impl<A: Aead> Default for AeadNonce<A> {
     fn default() -> AeadNonce<A> {
-        AeadNonce(GenericArray::<u8, <A::AeadImpl as AeadCore>::NonceSize>::default())
+        AeadNonce(GenericArray::<u8, <A::AeadImpl as BaseAeadCore>::NonceSize>::default())
     }
 }
 
@@ -119,10 +119,10 @@ fn mix_nonce<A: Aead>(base_nonce: &AeadNonce<A>, seq: &Seq) -> AeadNonce<A> {
 }
 
 /// An authenticated encryption tag
-pub struct AeadTag<A: Aead>(GenericArray<u8, <A::AeadImpl as AeadCore>::TagSize>);
+pub struct AeadTag<A: Aead>(GenericArray<u8, <A::AeadImpl as BaseAeadCore>::TagSize>);
 
 impl<A: Aead> Serializable for AeadTag<A> {
-    type OutputSize = <A::AeadImpl as AeadCore>::TagSize;
+    type OutputSize = <A::AeadImpl as BaseAeadCore>::TagSize;
 
     fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
         self.0.clone()
@@ -383,7 +383,7 @@ mod test {
     use super::{Aead, AeadTag, AesGcm128, AesGcm256, ChaCha20Poly1305, ExportOnlyAead, Seq};
     use crate::{kdf::HkdfSha256, kex::Deserializable, test_util::gen_ctx_simple_pair, HpkeError};
 
-    use aead::AeadCore;
+    use aead::AeadCore as BaseAeadCore;
     use generic_array::GenericArray;
 
     /// Tests that encryption context secret export does not change behavior based on the
@@ -454,7 +454,7 @@ mod test {
                 let mut ciphertext = *b"back hand";
                 let aad = b"with my prayers";
                 // The contents of the tag doesn't matter. This will panic before the take is read
-                type TagSize = <<A as Aead>::AeadImpl as AeadCore>::TagSize;
+                type TagSize = <<A as Aead>::AeadImpl as BaseAeadCore>::TagSize;
                 let tag = AeadTag(GenericArray::<u8, TagSize>::default());
 
                 let _ = receiver_ctx.open(&mut ciphertext[..], aad, &tag);

--- a/src/aead/export_only.rs
+++ b/src/aead/export_only.rs
@@ -1,6 +1,6 @@
 use crate::aead::Aead;
 
-use aead::{AeadCore, AeadInPlace, NewAead as BaseNewAead};
+use aead::{AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, NewAead as BaseNewAead};
 use generic_array::typenum;
 
 /// An inert underlying Aead implementation. The open/seal routines panic. The `new()` function
@@ -9,7 +9,7 @@ use generic_array::typenum;
 #[derive(Clone)]
 pub struct EmptyAeadImpl;
 
-impl AeadCore for EmptyAeadImpl {
+impl BaseAeadCore for EmptyAeadImpl {
     // The nonce size has to be bigger than the sequence size (currently u64), otherwise we get an
     // underflow error on seal()/open() before we can even panic
     type NonceSize = typenum::U128;
@@ -17,7 +17,7 @@ impl AeadCore for EmptyAeadImpl {
     type CiphertextOverhead = typenum::U0;
 }
 
-impl AeadInPlace for EmptyAeadImpl {
+impl BaseAeadInPlace for EmptyAeadImpl {
     fn encrypt_in_place_detached(
         &self,
         _: &aead::Nonce<Self>,

--- a/src/aead/export_only.rs
+++ b/src/aead/export_only.rs
@@ -1,6 +1,6 @@
 use crate::aead::Aead;
 
-use aead::{AeadInPlace as BaseAead, NewAead as BaseNewAead};
+use aead::{AeadCore, AeadInPlace, NewAead as BaseNewAead};
 use generic_array::typenum;
 
 /// An inert underlying Aead implementation. The open/seal routines panic. The `new()` function
@@ -9,28 +9,30 @@ use generic_array::typenum;
 #[derive(Clone)]
 pub struct EmptyAeadImpl;
 
-impl BaseAead for EmptyAeadImpl {
+impl AeadCore for EmptyAeadImpl {
     // The nonce size has to be bigger than the sequence size (currently u64), otherwise we get an
     // underflow error on seal()/open() before we can even panic
     type NonceSize = typenum::U128;
     type TagSize = typenum::U0;
     type CiphertextOverhead = typenum::U0;
+}
 
+impl AeadInPlace for EmptyAeadImpl {
     fn encrypt_in_place_detached(
         &self,
-        _: &aead::Nonce<Self::NonceSize>,
+        _: &aead::Nonce<Self>,
         _: &[u8],
         _: &mut [u8],
-    ) -> Result<aead::Tag<Self::TagSize>, aead::Error> {
+    ) -> Result<aead::Tag<Self>, aead::Error> {
         panic!("Cannot encrypt with an export-only encryption context!");
     }
 
     fn decrypt_in_place_detached(
         &self,
-        _: &aead::Nonce<Self::NonceSize>,
+        _: &aead::Nonce<Self>,
         _: &[u8],
         _: &mut [u8],
-        _: &aead::Tag<Self::TagSize>,
+        _: &aead::Tag<Self>,
     ) -> Result<(), aead::Error> {
         panic!("Cannot decrypt with an export-only encryption context!");
     }


### PR DESCRIPTION
`cargo audit --deny warnings` currently complains because some crates used in the dependency tree are not maintained anymore and have been merged into `aes`:
```
Crate:         aes-soft
Version:       0.6.4
Warning:       unmaintained
Title:         `aes-soft` has been merged into the `aes` crate
Date:          2021-04-29
ID:            RUSTSEC-2021-0060
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0060
Dependency tree: 
aes-soft 0.6.4
└── aes 0.6.0
    └── aes-gcm 0.8.0
        └── hpke 0.5.1

Crate:         aesni
Version:       0.10.0
Warning:       unmaintained
Title:         `aesni` has been merged into the `aes` crate
Date:          2021-04-29
ID:            RUSTSEC-2021-0059
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0059
Dependency tree: 
aesni 0.10.0
└── aes 0.6.0
    └── aes-gcm 0.8.0
        └── hpke 0.5.1
```

I tried to update those dependencies because those warnings are breaking our CI but I am encountering some compilation error because of `AeadCore` not being implemented for some types that have nothing to do with that traits.