### PR TITLE
Allow non DH-based kem

### DIFF
--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -80,7 +80,8 @@ pub(crate) fn extract_and_expand<Kem: KemTrait>(
 //   labeled_ikm = concat("HPKE-05 ", suite_id, label, ikm)
 //   return Extract(salt, labeled_ikm)
 /// Returns the HKDF context derived from `(salt=salt, ikm="HPKE-05 "||suite_id||label||ikm)`
-pub(crate) fn labeled_extract<Kdf: KdfTrait>(
+// need to be public to allow external implementation of kex::derive_keypair
+pub fn labeled_extract<Kdf: KdfTrait>(
     salt: &[u8],
     suite_id: &[u8],
     label: &[u8],
@@ -99,7 +100,8 @@ pub(crate) fn labeled_extract<Kdf: KdfTrait>(
 }
 
 // This trait only exists so I can implement it for hkdf::Hkdf
-pub(crate) trait LabeledExpand {
+// need to be public to allow external implementation of kex::derive_keypair
+pub trait LabeledExpand {
     fn labeled_expand(
         &self,
         suite_id: &[u8],

--- a/src/kex.rs
+++ b/src/kex.rs
@@ -64,8 +64,35 @@ pub trait KeyExchange {
     #[cfg(not(feature = "serde_impls"))]
     type PrivateKey: Clone + Serializable + Deserializable;
 
+    #[cfg(feature = "serde_impls")]
+    type EncappedKey: Clone
+        + Serializable
+        + Deserializable
+        + SerdeSerialize
+        + for<'a> SerdeDeserialize<'a>;
+    #[cfg(not(feature = "serde_impls"))]
+    type EncappedKey: Clone + Serializable + Deserializable;
+
+    #[doc(hidden)]
+    type EphemeralSecret;
+
+    #[doc(hidden)]
+    type DerivEphResult: Serializable;
+
     #[doc(hidden)]
     type KexResult: Serializable;
+
+    #[doc(hidden)]
+    fn derive_and_encap_eph(
+        sk: &Self::EphemeralSecret,
+        pk: &Self::PublicKey,
+    ) -> Result<(Self::DerivEphResult, Self::EncappedKey), KexError>;
+
+    #[doc(hidden)]
+    fn decap_eph(
+        sk: &Self::PrivateKey,
+        encapk: &Self::EncappedKey,
+    ) -> Result<Self::DerivEphResult, KexError>;
 
     #[doc(hidden)]
     fn sk_to_pk(sk: &Self::PrivateKey) -> Self::PublicKey;

--- a/src/kex/ecdh_nistp.rs
+++ b/src/kex/ecdh_nistp.rs
@@ -103,7 +103,29 @@ impl KeyExchange for DhP256 {
     #[doc(hidden)]
     type PrivateKey = PrivateKey;
     #[doc(hidden)]
+    type EphemeralSecret = PrivateKey;
+    #[doc(hidden)]
+    type EncappedKey = PublicKey;
+    #[doc(hidden)]
+    type DerivEphResult = KexResult;
+    #[doc(hidden)]
     type KexResult = KexResult;
+
+    #[doc(hidden)]
+    fn derive_and_encap_eph(
+        sk: &Self::EphemeralSecret,
+        pk: &Self::PublicKey,
+    ) -> Result<(Self::DerivEphResult, Self::EncappedKey), KexError> {
+        Ok((Self::kex(sk, pk)?, Self::sk_to_pk(sk)))
+    }
+
+    #[doc(hidden)]
+    fn decap_eph(
+        sk: &Self::PrivateKey,
+        encapk: &Self::EncappedKey,
+    ) -> Result<Self::DerivEphResult, KexError> {
+        Self::kex(sk, encapk)
+    }
 
     /// Converts an P256 private key to a public key
     #[doc(hidden)]

--- a/src/kex/x25519.rs
+++ b/src/kex/x25519.rs
@@ -100,7 +100,29 @@ impl KeyExchange for X25519 {
     #[doc(hidden)]
     type PrivateKey = PrivateKey;
     #[doc(hidden)]
+    type EphemeralSecret = PrivateKey;
+    #[doc(hidden)]
+    type EncappedKey = PublicKey;
+    #[doc(hidden)]
+    type DerivEphResult = KexResult;
+    #[doc(hidden)]
     type KexResult = KexResult;
+
+    #[doc(hidden)]
+    fn derive_and_encap_eph(
+        sk: &Self::EphemeralSecret,
+        pk: &Self::PublicKey,
+    ) -> Result<(Self::DerivEphResult, Self::EncappedKey), KexError> {
+        Ok((Self::kex(sk, pk)?, Self::sk_to_pk(sk)))
+    }
+
+    #[doc(hidden)]
+    fn decap_eph(
+        sk: &Self::PrivateKey,
+        encapk: &Self::EncappedKey,
+    ) -> Result<Self::DerivEphResult, KexError> {
+        Self::kex(sk, encapk)
+    }
 
     /// Converts an X25519 private key to a public key
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod test_util;
 pub use generic_array;
 
 #[macro_use]
-mod util;
+pub mod util;
 
 pub mod aead;
 pub mod kdf;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use crate::{aead::Aead, kdf::Kdf as KdfTrait, kem::Kem as KemTrait, HpkeError};
 use byteorder::{BigEndian, ByteOrder};
 
 /// Represents a ciphersuite context. That's "KEMXX", where `XX` is the KEM ID
-pub(crate) type KemSuiteId = [u8; 5];
+pub type KemSuiteId = [u8; 5];
 
 /// Represents a ciphersuite context. That's "HPKEXXYYZZ", where `XX` is the KEM ID, `YY` is the
 /// KDF ID, and `ZZ` is the AEAD ID


### PR DESCRIPTION
- Some internal structs needs to be public to allow external implementation of the trait `Kex`
- Add function to identify ephemeral secret not as a public key