### PR TITLE
Make `kem::EncappedKey` implement `Clone`

### DIFF
--- a/src/kem.rs
+++ b/src/kem.rs
@@ -89,6 +89,7 @@ type KemPrivkey<Kem> = <<Kem as KemTrait>::Kex as KeyExchange>::PrivateKey;
 /// Holds the content of an encapsulated secret. This is what the receiver uses to derive the
 /// shared secret.
 // This just wraps a pubkey, because that's all an encapsulated key is in a DH-KEM
+#[derive(Clone)]
 pub struct EncappedKey<Kex: KeyExchange>(Kex::PublicKey);
 
 // EncappedKeys need to be serializable, since they're gonna be sent over the wire. Underlyingly,


### PR DESCRIPTION
Derive an `std::clone::Clone` implemnetation on `kem::EncappedKey` so
that it can be used as a field in structs that are in turn `Clone`.
`EncappedKey` is just a tuple struct around `KeyExchange::PublicKey`,
which is already required to implement `Clone` by trait
`kex::KeyExchange`.
