### PR TITLE
Initial changes to get `wasm-pack build` to succeed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_impls = ["serde", "generic-array/serde"]
 # The std feature has no function outside of doing KAT tests. There is no need to use this in
 # production.
 std = []
+wasm = ["getrandom"]
 
 [dependencies]
 aead = "0.4"
@@ -37,6 +38,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }
 paste = "1.0"
+getrandom = { version = "0.2.6", features = ["js", "js-sys"], optional = true }
 
 [dependencies.x25519-dalek]
 version = "1.2"
@@ -71,4 +73,4 @@ harness = false
 
 [lib]
 bench = false
-
+crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
I do not yet have high confidence that this is the sufficient, but I do believe these changes are necessary. getrandom is currently a transitive dep, but we need to enable the js feature. I believe 1.60 has some special support for this, but in order to keep the msrv as is, I just added a direct dependency on getrandom when the `wasm` feature is enabled.

closes #21 (?)

Thanks!