### PR TITLE
KEM interface tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ sha2 = { version = "0.9", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }
-paste = "1.0"
 
 [dependencies.x25519-dalek]
 version = "1.2"

--- a/src/kat_tests.rs
+++ b/src/kat_tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     aead::{Aead, AesGcm128, AesGcm256, ChaCha20Poly1305, ExportOnlyAead},
     kdf::{HkdfSha256, HkdfSha384, HkdfSha512, Kdf as KdfTrait},
-    kem::{DhP256HkdfSha256, Kem as KemTrait, SharedSecret, X25519HkdfSha256},
+    kem::{self, DhP256HkdfSha256, Kem as KemTrait, SharedSecret, X25519HkdfSha256},
     op_mode::{OpModeR, PskBundle},
     setup::setup_receiver,
     Deserializable, HpkeError, Serializable,
@@ -40,7 +40,7 @@ impl TestableKem for X25519HkdfSha256 {
         sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
         sk_eph: Self::EphemeralKey,
     ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
-        crate::kem::x25519_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
+        kem::x25519_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
     }
 }
 impl TestableKem for DhP256HkdfSha256 {
@@ -53,7 +53,7 @@ impl TestableKem for DhP256HkdfSha256 {
         sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
         sk_eph: Self::EphemeralKey,
     ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
-        crate::kem::dhp256_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
+        kem::dhp256_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
     }
 }
 

--- a/src/kat_tests.rs
+++ b/src/kat_tests.rs
@@ -197,9 +197,10 @@ fn test_case<A: Aead, Kdf: KdfTrait, Kem: KemTrait>(tv: MainTestVector) {
 
     // Now derive the encapped key with the deterministic encap function, using all the inputs
     // above
-    let (shared_secret, encapped_key) =
-        Kem::encap_with_eph(&pk_recip, sender_keypair.as_ref(), sk_eph.clone())
-            .expect("encap failed");
+    let (shared_secret, encapped_key) = {
+        let sender_keypair_ref = sender_keypair.as_ref().map(|&(ref sk, ref pk)| (sk, pk));
+        Kem::encap_with_eph(&pk_recip, sender_keypair_ref, sk_eph.clone()).expect("encap failed")
+    };
 
     // Assert that the derived shared secret key is identical to the one provided
     assert_eq!(

--- a/src/kat_tests.rs
+++ b/src/kat_tests.rs
@@ -1,10 +1,10 @@
 use crate::{
     aead::{Aead, AesGcm128, AesGcm256, ChaCha20Poly1305, ExportOnlyAead},
     kdf::{HkdfSha256, HkdfSha384, HkdfSha512, Kdf as KdfTrait},
-    kem::{DhP256HkdfSha256, Kem as KemTrait, X25519HkdfSha256},
+    kem::{DhP256HkdfSha256, Kem as KemTrait, SharedSecret, X25519HkdfSha256},
     op_mode::{OpModeR, PskBundle},
     setup::setup_receiver,
-    Deserializable, Serializable,
+    Deserializable, HpkeError, Serializable,
 };
 
 extern crate std;
@@ -13,6 +13,49 @@ use std::{fs::File, string::String, vec::Vec};
 use hex;
 use serde::{de::Error as SError, Deserialize, Deserializer};
 use serde_json;
+
+// For known-answer tests we need to be able to encap with fixed randomness. This allows that.
+trait TestableKem: KemTrait {
+    /// The ephemeral key used in encapsulation. This is the same thing as a private key in the
+    /// case of DHKEM, but this is not always true
+    type EphemeralKey: Deserializable;
+
+    // Encap with fixed randomness
+    #[doc(hidden)]
+    fn encap_with_eph(
+        pk_recip: &Self::PublicKey,
+        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
+        sk_eph: Self::EphemeralKey,
+    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError>;
+}
+
+// Now implement TestableKem for all the KEMs in the KAT
+impl TestableKem for X25519HkdfSha256 {
+    // In DHKEM, ephemeral keys and private keys are both scalars
+    type EphemeralKey = <X25519HkdfSha256 as KemTrait>::PrivateKey;
+
+    // Call the x25519 deterministic encap function we defined in dhkem.rs
+    fn encap_with_eph(
+        pk_recip: &Self::PublicKey,
+        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
+        sk_eph: Self::EphemeralKey,
+    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
+        crate::kem::x25519_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
+    }
+}
+impl TestableKem for DhP256HkdfSha256 {
+    // In DHKEM, ephemeral keys and private keys are both scalars
+    type EphemeralKey = <DhP256HkdfSha256 as KemTrait>::PrivateKey;
+
+    // Call the p256 deterministic encap function we defined in dhkem.rs
+    fn encap_with_eph(
+        pk_recip: &Self::PublicKey,
+        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
+        sk_eph: Self::EphemeralKey,
+    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
+        crate::kem::dhp256_hkdfsha256::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
+    }
+}
 
 /// Asserts that the given serializable values are equal
 macro_rules! assert_serializable_eq {
@@ -59,7 +102,7 @@ struct MainTestVector {
     #[serde(default, rename = "ikmS", deserialize_with = "bytes_from_hex_opt")]
     ikm_sender: Option<Vec<u8>>,
     #[serde(rename = "ikmE", deserialize_with = "bytes_from_hex")]
-    ikm_eph: Vec<u8>,
+    _ikm_eph: Vec<u8>,
 
     // Private keys
     #[serde(rename = "skRm", deserialize_with = "bytes_from_hex")]
@@ -81,7 +124,7 @@ struct MainTestVector {
     #[serde(default, rename = "pkSm", deserialize_with = "bytes_from_hex_opt")]
     pk_sender: Option<Vec<u8>>,
     #[serde(rename = "pkEm", deserialize_with = "bytes_from_hex")]
-    pk_eph: Vec<u8>,
+    _pk_eph: Vec<u8>,
 
     // Key schedule inputs and computations
     #[serde(rename = "enc", deserialize_with = "bytes_from_hex")]
@@ -164,10 +207,10 @@ fn make_op_mode_r<'a, Kem: KemTrait>(
 }
 
 // This does all the legwork
-fn test_case<A: Aead, Kdf: KdfTrait, Kem: KemTrait>(tv: MainTestVector) {
+fn test_case<A: Aead, Kdf: KdfTrait, Kem: TestableKem>(tv: MainTestVector) {
     // First, deserialize all the relevant keys so we can reconstruct the encapped key
     let recip_keypair = deser_keypair::<Kem>(&tv.sk_recip, &tv.pk_recip);
-    let eph_keypair = deser_keypair::<Kem>(&tv.sk_eph, &tv.pk_eph);
+    let sk_eph = <Kem as TestableKem>::EphemeralKey::from_bytes(&tv.sk_eph).unwrap();
     let sender_keypair = {
         let pk_sender = &tv.pk_sender.as_ref();
         tv.sk_sender
@@ -181,11 +224,6 @@ fn test_case<A: Aead, Kdf: KdfTrait, Kem: KemTrait>(tv: MainTestVector) {
         assert_serializable_eq!(recip_keypair.0, derived_kp.0, "sk recip doesn't match");
         assert_serializable_eq!(recip_keypair.1, derived_kp.1, "pk recip doesn't match");
     }
-    {
-        let derived_kp = Kem::derive_keypair(&tv.ikm_eph);
-        assert_serializable_eq!(eph_keypair.0, derived_kp.0, "sk eph doesn't match");
-        assert_serializable_eq!(eph_keypair.1, derived_kp.1, "pk eph doesn't match");
-    }
     if let Some(sks) = sender_keypair.as_ref() {
         let derived_kp = Kem::derive_keypair(&tv.ikm_sender.unwrap());
         assert_serializable_eq!(sks.0, derived_kp.0, "sk sender doesn't match");
@@ -193,13 +231,12 @@ fn test_case<A: Aead, Kdf: KdfTrait, Kem: KemTrait>(tv: MainTestVector) {
     }
 
     let (sk_recip, pk_recip) = recip_keypair;
-    let (sk_eph, _) = eph_keypair;
 
     // Now derive the encapped key with the deterministic encap function, using all the inputs
     // above
     let (shared_secret, encapped_key) = {
         let sender_keypair_ref = sender_keypair.as_ref().map(|&(ref sk, ref pk)| (sk, pk));
-        Kem::encap_with_eph(&pk_recip, sender_keypair_ref, sk_eph.clone()).expect("encap failed")
+        Kem::encap_with_eph(&pk_recip, sender_keypair_ref, sk_eph).expect("encap failed")
     };
 
     // Assert that the derived shared secret key is identical to the one provided

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -70,7 +70,8 @@ impl KdfTrait for HkdfSha512 {
 
 /// Uses the given IKM to extract a secret, and then uses that secret, plus the given suite ID and
 /// info string, to expand to the output buffer
-pub(crate) fn extract_and_expand<Kdf: KdfTrait>(
+#[doc(hidden)]
+pub fn extract_and_expand<Kdf: KdfTrait>(
     ikm: &[u8],
     suite_id: &[u8],
     info: &[u8],
@@ -88,7 +89,8 @@ pub(crate) fn extract_and_expand<Kdf: KdfTrait>(
 //   return Extract(salt, labeled_ikm)
 
 /// Returns the HKDF context derived from `(salt=salt, ikm="HPKE-05 "||suite_id||label||ikm)`
-pub(crate) fn labeled_extract<Kdf: KdfTrait>(
+#[doc(hidden)]
+pub fn labeled_extract<Kdf: KdfTrait>(
     salt: &[u8],
     suite_id: &[u8],
     label: &[u8],

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -78,7 +78,7 @@ pub trait Kem: Sized {
     #[doc(hidden)]
     fn encap_with_eph(
         pk_recip: &Self::PublicKey,
-        sender_id_keypair: Option<&(Self::PrivateKey, Self::PublicKey)>,
+        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
         sk_eph: Self::PrivateKey,
     ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError>;
 
@@ -108,7 +108,7 @@ pub trait Kem: Sized {
     #[doc(hidden)]
     fn encap<R: CryptoRng + RngCore>(
         pk_recip: &Self::PublicKey,
-        sender_id_keypair: Option<&(Self::PrivateKey, Self::PublicKey)>,
+        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
         csprng: &mut R,
     ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
         // Generate a new ephemeral keypair
@@ -123,7 +123,7 @@ use Kem as KemTrait;
 
 /// A convenience type for `[u8; NSecret]` for any given KEM
 #[doc(hidden)]
-pub struct SharedSecret<Kem: KemTrait>(pub(crate) GenericArray<u8, Kem::NSecret>);
+pub struct SharedSecret<Kem: KemTrait>(pub GenericArray<u8, Kem::NSecret>);
 
 impl<Kem: KemTrait> Default for SharedSecret<Kem> {
     fn default() -> SharedSecret<Kem> {
@@ -180,7 +180,7 @@ mod tests {
                 // Encapsulate a random shared secret
                 let (auth_shared_secret, encapped_key) = Kem::encap(
                     &pk_recip,
-                    Some(&(sk_sender_id, pk_sender_id.clone())),
+                    Some((&sk_sender_id, &pk_sender_id.clone())),
                     &mut csprng,
                 )
                 .unwrap();

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -39,12 +39,16 @@ pub trait Kem: Sized {
     #[cfg(not(feature = "serde_impls"))]
     type PrivateKey: Clone + Serializable + Deserializable;
 
+    /// The encapsulated key for this KEM. This is used by the recipient to derive the shared
+    /// secret.
     #[cfg(feature = "serde_impls")]
     type EncappedKey: Clone
         + Serializable
         + Deserializable
         + SerdeSerialize
         + for<'a> SerdeDeserialize<'a>;
+    /// The encapsulated key for this KEM. This is used by the recipient to derive the shared
+    /// secret.
     #[cfg(not(feature = "serde_impls"))]
     type EncappedKey: Clone + Serializable + Deserializable;
 
@@ -75,21 +79,6 @@ pub trait Kem: Sized {
         Self::derive_keypair(&ikm)
     }
 
-    /// Derives a shared secret that the owner of the recipient's pubkey can use to derive the same
-    /// shared secret. If `sk_sender_id` is given, the sender's identity will be tied to the shared
-    /// secret.
-    ///
-    /// Return Value
-    /// ============
-    /// Returns a shared secret and encapped key on success. If an error happened during key
-    /// exchange, returns `Err(HpkeError::EncapError)`.
-    #[doc(hidden)]
-    fn encap_with_eph(
-        pk_recip: &Self::PublicKey,
-        sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
-        sk_eph: Self::PrivateKey,
-    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError>;
-
     /// Derives a shared secret given the encapsulated key and the recipients secret key. If
     /// `pk_sender_id` is given, the sender's identity will be tied to the shared secret.
     ///
@@ -118,12 +107,7 @@ pub trait Kem: Sized {
         pk_recip: &Self::PublicKey,
         sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
         csprng: &mut R,
-    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
-        // Generate a new ephemeral keypair
-        let (sk_eph, _) = Self::gen_keypair(csprng);
-        // Now pass to encap_with_eph
-        Self::encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
-    }
+    ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError>;
 }
 
 // Kem is used as a type parameter everywhere. To avoid confusion, alias it

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -1,19 +1,10 @@
-use crate::{
-    dhkex::{DhKeyExchange, MAX_PUBKEY_SIZE},
-    kdf::{extract_and_expand, Kdf as KdfTrait},
-    kem::{Kem as KemTrait, SharedSecret},
-    util::kem_suite_id,
-    Deserializable, HpkeError, Serializable,
-};
-
-use digest::FixedOutput;
-use generic_array::GenericArray;
 use paste::paste;
 
 /// Defines DHKEM(G, K) given a Diffie-Hellman group G and KDF K
 macro_rules! impl_dhkem {
     // Top-level case. Creates the ident for the encapped key type and calls to the base case
     (
+        $mod_name:ident,
         $kem_name:ident,
         $dhkex:ty,
         $kdf:ty,
@@ -22,6 +13,7 @@ macro_rules! impl_dhkem {
     ) => {
         paste! {
             impl_dhkem!(
+                $mod_name,
                 $kem_name,
                 [<$kem_name EncappedKey>],
                 $dhkex,
@@ -35,6 +27,7 @@ macro_rules! impl_dhkem {
     // Base case. Implements the given KEM with the given KDF type, encapped key type, DHKEX types,
     // etc.
     (
+        $mod_name:ident,
         $kem_name:ident,
         $encapped_key:ident,
         $dhkex:ty,
@@ -42,71 +35,58 @@ macro_rules! impl_dhkem {
         $kem_id:literal,
         $doc_str:expr
     ) => {
-        /// Holds the content of an encapsulated secret. This is what the receiver uses to derive
-        /// the shared secret. This just wraps a pubkey, because that's all an encapsulated key is
-        /// in a DH-KEM
-        #[doc(hidden)]
-        #[derive(Clone)]
-        pub struct $encapped_key(pub(crate) <$dhkex as DhKeyExchange>::PublicKey);
 
-        // EncappedKeys need to be serializable, since they're gonna be sent over the wire.
-        // Underlyingly, they're just DH pubkeys, so we just serialize them the same way
-        impl Serializable for $encapped_key {
-            type OutputSize = <<$dhkex as DhKeyExchange>::PublicKey as Serializable>::OutputSize;
+        // Export everything from the crate we define
+        pub use $mod_name::*;
 
-            // Pass to underlying to_bytes() impl
-            fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
-                self.0.to_bytes()
-            }
-        }
+        pub(crate) mod $mod_name {
+            use crate::{
+                dhkex::{DhKeyExchange, MAX_PUBKEY_SIZE},
+                kdf::{extract_and_expand, Kdf as KdfTrait},
+                kem::{Kem as KemTrait, SharedSecret},
+                util::kem_suite_id,
+                Deserializable, HpkeError, Serializable,
+            };
 
-        impl Deserializable for $encapped_key {
-            // Pass to underlying from_bytes() impl
-            fn from_bytes(encoded: &[u8]) -> Result<Self, HpkeError> {
-                let pubkey =
-                    <<$dhkex as DhKeyExchange>::PublicKey as Deserializable>::from_bytes(encoded)?;
-                Ok($encapped_key(pubkey))
-            }
-        }
+            use digest::FixedOutput;
+            use generic_array::GenericArray;
+            use rand_core::{CryptoRng, RngCore};
 
-        // Define the KEM struct
-        #[doc = $doc_str]
-        pub struct $kem_name;
-
-        impl KemTrait for $kem_name {
-            // draft12 §4.1
-            // For the variants of DHKEM defined in this document, the size "Nsecret" of the KEM
-            // shared secret is equal to the output length of the hash function underlying the KDF
-
-            /// The size of the shared secret at the end of the key exchange process
-            #[doc(hidden)]
-            type NSecret = <<$kdf as KdfTrait>::HashImpl as FixedOutput>::OutputSize;
-
-            // draft12 §4.1
-            // The function parameters "pkR" and "pkS" are deserialized public keys, and
-            // "enc" is a serialized public key.  Since encapsulated keys are Diffie-Hellman public
-            // keys in this KEM algorithm, we use "SerializePublicKey()" and
-            // "DeserializePublicKey()" to encode and decode them, respectively.  "Npk" equals
-            // "Nenc". "GenerateKeyPair()" produces a key pair for the Diffie-Hellman group in use.
-            // Section 7.1.3 contains the "DeriveKeyPair()" function specification for DHKEMs
-            // defined in this document.
+            // Define convenience types
             type PublicKey = <$dhkex as DhKeyExchange>::PublicKey;
             type PrivateKey = <$dhkex as DhKeyExchange>::PrivateKey;
             type EncappedKey = $encapped_key;
 
-            const KEM_ID: u16 = $kem_id;
+            /// Holds the content of an encapsulated secret. This is what the receiver uses to derive
+            /// the shared secret. This just wraps a pubkey, because that's all an encapsulated key is
+            /// in a DH-KEM
+            #[doc(hidden)]
+            #[derive(Clone)]
+            pub struct $encapped_key(pub(crate) <$dhkex as DhKeyExchange>::PublicKey);
 
-            /// Deterministically derives a keypair from the given input keying material
-            ///
-            /// Requirements
-            /// ============
-            /// This keying material SHOULD have as many bits of entropy as the bit length of a
-            /// secret key, i.e., `8 * Self::PrivateKey::size()`. For X25519 and P-256, this is
-            /// 256 bits of entropy.
-            fn derive_keypair(ikm: &[u8]) -> (Self::PrivateKey, Self::PublicKey) {
-                let suite_id = kem_suite_id::<Self>();
-                <$dhkex as DhKeyExchange>::derive_keypair::<$kdf>(&suite_id, ikm)
+            // EncappedKeys need to be serializable, since they're gonna be sent over the wire.
+            // Underlyingly, they're just DH pubkeys, so we just serialize them the same way
+            impl Serializable for $encapped_key {
+                type OutputSize = <<$dhkex as DhKeyExchange>::PublicKey as Serializable>::OutputSize;
+
+                // Pass to underlying to_bytes() impl
+                fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+                    self.0.to_bytes()
+                }
             }
+
+            impl Deserializable for $encapped_key {
+                // Pass to underlying from_bytes() impl
+                fn from_bytes(encoded: &[u8]) -> Result<Self, HpkeError> {
+                    let pubkey =
+                        <<$dhkex as DhKeyExchange>::PublicKey as Deserializable>::from_bytes(encoded)?;
+                    Ok($encapped_key(pubkey))
+                }
+            }
+
+            // Define the KEM struct
+            #[doc = $doc_str]
+            pub struct $kem_name;
 
             // draft12 §4.1
             // def Encap(pkR):
@@ -129,6 +109,10 @@ macro_rules! impl_dhkem {
             //   shared_secret = ExtractAndExpand(dh, kem_context)
             //   return shared_secret, enc
 
+            // The reason we define encap_with_eph() rather than just encap() is because we need to
+            // use deterministic ephemeral keys in the known-answer tests. So we define a function
+            // here, then use it to impl kem::Kem and kat_tests::TestableKem.
+
             /// Derives a shared secret that the owner of the recipient's pubkey can use to derive
             /// the same shared secret. If `sk_sender_id` is given, the sender's identity will be
             /// tied to the shared secret.
@@ -138,13 +122,13 @@ macro_rules! impl_dhkem {
             /// Returns a shared secret and encapped key on success. If an error happened during
             /// key exchange, returns `Err(HpkeError::EncapError)`.
             #[doc(hidden)]
-            fn encap_with_eph(
-                pk_recip: &Self::PublicKey,
-                sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
-                sk_eph: Self::PrivateKey,
-            ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
+            pub(crate) fn encap_with_eph(
+                pk_recip: &PublicKey,
+                sender_id_keypair: Option<(&PrivateKey, &PublicKey)>,
+                sk_eph: PrivateKey,
+            ) -> Result<(SharedSecret<$kem_name>, EncappedKey), HpkeError> {
                 // Put together the binding context used for all KDF operations
-                let suite_id = kem_suite_id::<Self>();
+                let suite_id = kem_suite_id::<$kem_name>();
 
                 // Compute the shared secret from the ephemeral inputs
                 let kex_res_eph = <$dhkex as DhKeyExchange>::dh(&sk_eph, pk_recip)
@@ -189,14 +173,9 @@ macro_rules! impl_dhkem {
                     // recipient pubkey. The HKDF-Expand call only errors if the output values are
                     // 255x the digest size of the hash function. Since these values are fixed at
                     // compile time, we don't worry about it.
-                    let mut buf = <SharedSecret<Self> as Default>::default();
-                    extract_and_expand::<$kdf>(
-                        concatted_secrets,
-                        &suite_id,
-                        kem_context,
-                        &mut buf.0,
-                    )
-                    .expect("shared secret is way too big");
+                    let mut buf = <SharedSecret<$kem_name> as Default>::default();
+                    extract_and_expand::<$kdf>(concatted_secrets, &suite_id, kem_context, &mut buf.0)
+                        .expect("shared secret is way too big");
                     buf
                 } else {
                     // kem_context = encapped_key || pk_recip
@@ -213,7 +192,7 @@ macro_rules! impl_dhkem {
                     // input with the recipient pubkey. The HKDF-Expand call only errors if the
                     // output values are 255x the digest size of the hash function. Since these
                     // values are fixed at compile time, we don't worry about it.
-                    let mut buf = <SharedSecret<Self> as Default>::default();
+                    let mut buf = <SharedSecret<$kem_name> as Default>::default();
                     extract_and_expand::<$kdf>(
                         &kex_res_eph.to_bytes(),
                         &suite_id,
@@ -227,118 +206,166 @@ macro_rules! impl_dhkem {
                 Ok((shared_secret, encapped_key))
             }
 
-            // draft11 §4.1
-            // def Decap(enc, skR):
-            //   pkE = DeserializePublicKey(enc)
-            //   dh = DH(skR, pkE)
-            //
-            //   pkRm = SerializePublicKey(pk(skR))
-            //   kem_context = concat(enc, pkRm)
-            //
-            //   shared_secret = ExtractAndExpand(dh, kem_context)
-            //   return shared_secret
-            //
-            // def AuthDecap(enc, skR, pkS):
-            //   pkE = DeserializePublicKey(enc)
-            //   dh = concat(DH(skR, pkE), DH(skR, pkS))
-            //
-            //   pkRm = SerializePublicKey(pk(skR))
-            //   pkSm = SerializePublicKey(pkS)
-            //   kem_context = concat(enc, pkRm, pkSm)
-            //
-            //   shared_secret = ExtractAndExpand(dh, kem_context)
-            //   return shared_secret
+            impl KemTrait for $kem_name {
+                // draft12 §4.1
+                // For the variants of DHKEM defined in this document, the size "Nsecret" of the KEM
+                // shared secret is equal to the output length of the hash function underlying the KDF
 
-            /// Derives a shared secret given the encapsulated key and the recipients secret key.
-            /// If `pk_sender_id` is given, the sender's identity will be tied to the shared
-            /// secret.
-            ///
-            /// Return Value
-            /// ============
-            /// Returns a shared secret on success. If an error happened during key exchange,
-            /// returns `Err(HpkeError::DecapError)`.
-            #[doc(hidden)]
-            fn decap(
-                sk_recip: &Self::PrivateKey,
-                pk_sender_id: Option<&Self::PublicKey>,
-                encapped_key: &Self::EncappedKey,
-            ) -> Result<SharedSecret<Self>, HpkeError> {
-                // Put together the binding context used for all KDF operations
-                let suite_id = kem_suite_id::<Self>();
+                /// The size of the shared secret at the end of the key exchange process
+                #[doc(hidden)]
+                type NSecret = <<$kdf as KdfTrait>::HashImpl as FixedOutput>::OutputSize;
 
-                // Compute the shared secret from the ephemeral inputs
-                let kex_res_eph = <$dhkex as DhKeyExchange>::dh(sk_recip, &encapped_key.0)
-                    .map_err(|_| HpkeError::DecapError)?;
+                // draft12 §4.1
+                // The function parameters "pkR" and "pkS" are deserialized public keys, and
+                // "enc" is a serialized public key.  Since encapsulated keys are Diffie-Hellman public
+                // keys in this KEM algorithm, we use "SerializePublicKey()" and
+                // "DeserializePublicKey()" to encode and decode them, respectively.  "Npk" equals
+                // "Nenc". "GenerateKeyPair()" produces a key pair for the Diffie-Hellman group in use.
+                // Section 7.1.3 contains the "DeriveKeyPair()" function specification for DHKEMs
+                // defined in this document.
+                type PublicKey = <$dhkex as DhKeyExchange>::PublicKey;
+                type PrivateKey = <$dhkex as DhKeyExchange>::PrivateKey;
+                type EncappedKey = $encapped_key;
 
-                // Compute the sender's pubkey from their privkey
-                let pk_recip = <$dhkex as DhKeyExchange>::sk_to_pk(sk_recip);
+                const KEM_ID: u16 = $kem_id;
 
-                // The shared secret is either gonna be kex_res_eph, or that along with another
-                // shared secret that's tied to the sender's identity.
-                if let Some(pk_sender_id) = pk_sender_id {
-                    // kem_context = encapped_key || pk_recip || pk_sender_id We concat without
-                    // allocation by making a buffer of the maximum possible size, then taking the
-                    // appropriately sized slice.
-                    let (kem_context_buf, kem_context_size) = concat_with_known_maxlen!(
-                        MAX_PUBKEY_SIZE,
-                        &encapped_key.to_bytes(),
-                        &pk_recip.to_bytes(),
-                        &pk_sender_id.to_bytes()
-                    );
-                    let kem_context = &kem_context_buf[..kem_context_size];
+                /// Deterministically derives a keypair from the given input keying material
+                ///
+                /// Requirements
+                /// ============
+                /// This keying material SHOULD have as many bits of entropy as the bit length of a
+                /// secret key, i.e., `8 * Self::PrivateKey::size()`. For X25519 and P-256, this is
+                /// 256 bits of entropy.
+                fn derive_keypair(ikm: &[u8]) -> (Self::PrivateKey, Self::PublicKey) {
+                    let suite_id = kem_suite_id::<Self>();
+                    <$dhkex as DhKeyExchange>::derive_keypair::<$kdf>(&suite_id, ikm)
+                }
 
-                    // We want to do an authed encap. Do a DH exchange between the sender identity
-                    // secret key and the recipient's pubkey
-                    let kex_res_identity = <$dhkex as DhKeyExchange>::dh(sk_recip, pk_sender_id)
+                // Runs encap_with_eph using a random ephemeral key
+                fn encap<R: CryptoRng + RngCore>(
+                    pk_recip: &Self::PublicKey,
+                    sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
+                    csprng: &mut R,
+                ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
+                    // Generate a new ephemeral key
+                    let (sk_eph, _) = Self::gen_keypair(csprng);
+                    // Now pass to encap_with_eph()
+                    encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
+                }
+
+                // draft11 §4.1
+                // def Decap(enc, skR):
+                //   pkE = DeserializePublicKey(enc)
+                //   dh = DH(skR, pkE)
+                //
+                //   pkRm = SerializePublicKey(pk(skR))
+                //   kem_context = concat(enc, pkRm)
+                //
+                //   shared_secret = ExtractAndExpand(dh, kem_context)
+                //   return shared_secret
+                //
+                // def AuthDecap(enc, skR, pkS):
+                //   pkE = DeserializePublicKey(enc)
+                //   dh = concat(DH(skR, pkE), DH(skR, pkS))
+                //
+                //   pkRm = SerializePublicKey(pk(skR))
+                //   pkSm = SerializePublicKey(pkS)
+                //   kem_context = concat(enc, pkRm, pkSm)
+                //
+                //   shared_secret = ExtractAndExpand(dh, kem_context)
+                //   return shared_secret
+
+                /// Derives a shared secret given the encapsulated key and the recipients secret key.
+                /// If `pk_sender_id` is given, the sender's identity will be tied to the shared
+                /// secret.
+                ///
+                /// Return Value
+                /// ============
+                /// Returns a shared secret on success. If an error happened during key exchange,
+                /// returns `Err(HpkeError::DecapError)`.
+                #[doc(hidden)]
+                fn decap(
+                    sk_recip: &Self::PrivateKey,
+                    pk_sender_id: Option<&Self::PublicKey>,
+                    encapped_key: &Self::EncappedKey,
+                ) -> Result<SharedSecret<Self>, HpkeError> {
+                    // Put together the binding context used for all KDF operations
+                    let suite_id = kem_suite_id::<Self>();
+
+                    // Compute the shared secret from the ephemeral inputs
+                    let kex_res_eph = <$dhkex as DhKeyExchange>::dh(sk_recip, &encapped_key.0)
                         .map_err(|_| HpkeError::DecapError)?;
 
-                    // concatted_secrets = kex_res_eph || kex_res_identity
-                    // Same no-alloc concat trick as above
-                    let (concatted_secrets_buf, concatted_secret_size) = concat_with_known_maxlen!(
-                        MAX_PUBKEY_SIZE,
-                        &kex_res_eph.to_bytes(),
-                        &kex_res_identity.to_bytes()
-                    );
-                    let concatted_secrets = &concatted_secrets_buf[..concatted_secret_size];
+                    // Compute the sender's pubkey from their privkey
+                    let pk_recip = <$dhkex as DhKeyExchange>::sk_to_pk(sk_recip);
 
-                    // The "authed shared secret" is derived from the KEX of the ephemeral input
-                    // with the recipient pubkey, and the kex of the identity input with the
-                    // recipient pubkey. The HKDF-Expand call only errors if the output values are
-                    // 255x the digest size of the hash function. Since these values are fixed at
-                    // compile time, we don't worry about it.
-                    let mut shared_secret = <SharedSecret<Self> as Default>::default();
-                    extract_and_expand::<$kdf>(
-                        concatted_secrets,
-                        &suite_id,
-                        kem_context,
-                        &mut shared_secret.0,
-                    )
-                    .expect("shared secret is way too big");
-                    Ok(shared_secret)
-                } else {
-                    // kem_context = encapped_key || pk_recip || pk_sender_id
-                    // We concat without allocation by making a buffer of the maximum possible
-                    // size, then taking the appropriately sized slice.
-                    let (kem_context_buf, kem_context_size) = concat_with_known_maxlen!(
-                        MAX_PUBKEY_SIZE,
-                        &encapped_key.to_bytes(),
-                        &pk_recip.to_bytes()
-                    );
-                    let kem_context = &kem_context_buf[..kem_context_size];
+                    // The shared secret is either gonna be kex_res_eph, or that along with another
+                    // shared secret that's tied to the sender's identity.
+                    if let Some(pk_sender_id) = pk_sender_id {
+                        // kem_context = encapped_key || pk_recip || pk_sender_id We concat without
+                        // allocation by making a buffer of the maximum possible size, then taking the
+                        // appropriately sized slice.
+                        let (kem_context_buf, kem_context_size) = concat_with_known_maxlen!(
+                            MAX_PUBKEY_SIZE,
+                            &encapped_key.to_bytes(),
+                            &pk_recip.to_bytes(),
+                            &pk_sender_id.to_bytes()
+                        );
+                        let kem_context = &kem_context_buf[..kem_context_size];
 
-                    // The "unauthed shared secret" is derived from just the KEX of the ephemeral
-                    // input with the recipient pubkey. The HKDF-Expand call only errors if the
-                    // output values are 255x the digest size of the hash function. Since these
-                    // values are fixed at compile time, we don't worry about it.
-                    let mut shared_secret = <SharedSecret<Self> as Default>::default();
-                    extract_and_expand::<$kdf>(
-                        &kex_res_eph.to_bytes(),
-                        &suite_id,
-                        kem_context,
-                        &mut shared_secret.0,
-                    )
-                    .expect("shared secret is way too big");
-                    Ok(shared_secret)
+                        // We want to do an authed encap. Do a DH exchange between the sender identity
+                        // secret key and the recipient's pubkey
+                        let kex_res_identity = <$dhkex as DhKeyExchange>::dh(sk_recip, pk_sender_id)
+                            .map_err(|_| HpkeError::DecapError)?;
+
+                        // concatted_secrets = kex_res_eph || kex_res_identity
+                        // Same no-alloc concat trick as above
+                        let (concatted_secrets_buf, concatted_secret_size) = concat_with_known_maxlen!(
+                            MAX_PUBKEY_SIZE,
+                            &kex_res_eph.to_bytes(),
+                            &kex_res_identity.to_bytes()
+                        );
+                        let concatted_secrets = &concatted_secrets_buf[..concatted_secret_size];
+
+                        // The "authed shared secret" is derived from the KEX of the ephemeral input
+                        // with the recipient pubkey, and the kex of the identity input with the
+                        // recipient pubkey. The HKDF-Expand call only errors if the output values are
+                        // 255x the digest size of the hash function. Since these values are fixed at
+                        // compile time, we don't worry about it.
+                        let mut shared_secret = <SharedSecret<Self> as Default>::default();
+                        extract_and_expand::<$kdf>(
+                            concatted_secrets,
+                            &suite_id,
+                            kem_context,
+                            &mut shared_secret.0,
+                        )
+                        .expect("shared secret is way too big");
+                        Ok(shared_secret)
+                    } else {
+                        // kem_context = encapped_key || pk_recip || pk_sender_id
+                        // We concat without allocation by making a buffer of the maximum possible
+                        // size, then taking the appropriately sized slice.
+                        let (kem_context_buf, kem_context_size) = concat_with_known_maxlen!(
+                            MAX_PUBKEY_SIZE,
+                            &encapped_key.to_bytes(),
+                            &pk_recip.to_bytes()
+                        );
+                        let kem_context = &kem_context_buf[..kem_context_size];
+
+                        // The "unauthed shared secret" is derived from just the KEX of the ephemeral
+                        // input with the recipient pubkey. The HKDF-Expand call only errors if the
+                        // output values are 255x the digest size of the hash function. Since these
+                        // values are fixed at compile time, we don't worry about it.
+                        let mut shared_secret = <SharedSecret<Self> as Default>::default();
+                        extract_and_expand::<$kdf>(
+                            &kex_res_eph.to_bytes(),
+                            &suite_id,
+                            kem_context,
+                            &mut shared_secret.0,
+                        )
+                        .expect("shared secret is way too big");
+                        Ok(shared_secret)
+                    }
                 }
             }
         }
@@ -348,6 +375,7 @@ macro_rules! impl_dhkem {
 // Implement DHKEM(X25519, HKDF-SHA256)
 #[cfg(feature = "x25519-dalek")]
 impl_dhkem!(
+    x25519_hkdfsha256,
     X25519HkdfSha256,
     crate::dhkex::x25519::X25519,
     crate::kdf::HkdfSha256,
@@ -358,6 +386,7 @@ impl_dhkem!(
 // Implement DHKEM(P-256, HKDF-SHA256)
 #[cfg(feature = "p256")]
 impl_dhkem!(
+    dhp256_hkdfsha256,
     DhP256HkdfSha256,
     crate::dhkex::ecdh_nistp::DhP256,
     crate::kdf::HkdfSha256,

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -9,7 +9,6 @@ use crate::{
 use digest::FixedOutput;
 use generic_array::GenericArray;
 use paste::paste;
-use rand_core::{CryptoRng, RngCore};
 
 /// Defines DHKEM(G, K) given a Diffie-Hellman group G and KDF K
 macro_rules! impl_dhkem {
@@ -107,19 +106,6 @@ macro_rules! impl_dhkem {
             fn derive_keypair(ikm: &[u8]) -> (Self::PrivateKey, Self::PublicKey) {
                 let suite_id = kem_suite_id::<Self>();
                 <$dhkex as DhKeyExchange>::derive_keypair::<$kdf>(&suite_id, ikm)
-            }
-
-            /// Generates a random keypair using the given RNG
-            fn gen_keypair<R: CryptoRng + RngCore>(
-                csprng: &mut R,
-            ) -> (Self::PrivateKey, Self::PublicKey) {
-                // Make some keying material that's the size of a private key
-                let mut ikm: GenericArray<u8, <Self::PrivateKey as Serializable>::OutputSize> =
-                    GenericArray::default();
-                // Fill it with randomness
-                csprng.fill_bytes(&mut ikm);
-                // Run derive_keypair using the KEM's KDF
-                Self::derive_keypair(&ikm)
             }
 
             // draft12 §4.1

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -154,7 +154,7 @@ macro_rules! impl_dhkem {
             #[doc(hidden)]
             fn encap_with_eph(
                 pk_recip: &Self::PublicKey,
-                sender_id_keypair: Option<&(Self::PrivateKey, Self::PublicKey)>,
+                sender_id_keypair: Option<(&Self::PrivateKey, &Self::PublicKey)>,
                 sk_eph: Self::PrivateKey,
             ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
                 // Put together the binding context used for all KDF operations

--- a/src/op_mode.rs
+++ b/src/op_mode.rs
@@ -61,10 +61,10 @@ pub enum OpModeS<'a, Kem: KemTrait> {
 // Helpers functions for setup_sender and testing
 impl<'a, Kem: KemTrait> OpModeS<'a, Kem> {
     /// Returns the sender's identity pubkey if it's specified
-    pub(crate) fn get_sender_id_keypair(&self) -> Option<&(Kem::PrivateKey, Kem::PublicKey)> {
+    pub(crate) fn get_sender_id_keypair(&self) -> Option<(&Kem::PrivateKey, &Kem::PublicKey)> {
         match self {
-            OpModeS::Auth(keypair) => Some(keypair),
-            OpModeS::AuthPsk(keypair, _) => Some(keypair),
+            OpModeS::Auth(keypair) => Some((&keypair.0, &keypair.1)),
+            OpModeS::AuthPsk(keypair, _) => Some((&keypair.0, &keypair.1)),
             _ => None,
         }
     }

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -81,14 +81,14 @@ impl_serde_noparam!(dhkex::x25519::PrivateKey);
 #[cfg(feature = "x25519")]
 impl_serde_noparam!(dhkex::x25519::PublicKey);
 #[cfg(feature = "x25519")]
-impl_serde_noparam!(kem::X25519HkdfSha256EncappedKey);
+impl_serde_noparam!(kem::x25519_hkdfsha256::EncappedKey);
 
 #[cfg(feature = "p256")]
 impl_serde_noparam!(dhkex::ecdh_nistp::PrivateKey);
 #[cfg(feature = "p256")]
 impl_serde_noparam!(dhkex::ecdh_nistp::PublicKey);
 #[cfg(feature = "p256")]
-impl_serde_noparam!(kem::DhP256HkdfSha256EncappedKey);
+impl_serde_noparam!(kem::dhp256_hkdfsha256::EncappedKey);
 
 #[cfg(test)]
 mod test {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -349,13 +349,13 @@ mod test {
             test_setup_correctness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::X25519HkdfSha256
+            crate::kem::x25519_hkdfsha256::X25519HkdfSha256
         );
         test_setup_soundness!(
             test_setup_soundness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::X25519HkdfSha256
+            crate::kem::x25519_hkdfsha256::X25519HkdfSha256
         );
     }
 
@@ -367,13 +367,13 @@ mod test {
             test_setup_correctness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::DhP256HkdfSha256
+            crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256
         );
         test_setup_soundness!(
             test_setup_soundness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::DhP256HkdfSha256
+            crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256
         );
     }
 }

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -225,7 +225,7 @@ mod test {
         test_single_shot_correctness_x25519,
         ChaCha20Poly1305,
         HkdfSha256,
-        crate::kem::X25519HkdfSha256
+        crate::kem::x25519_hkdfsha256::X25519HkdfSha256
     );
 
     #[cfg(feature = "p256")]
@@ -233,6 +233,6 @@ mod test {
         test_single_shot_correctness_p256,
         ChaCha20Poly1305,
         HkdfSha256,
-        crate::kem::DhP256HkdfSha256
+        crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256
     );
 }


### PR DESCRIPTION
Made ergonomic changes to the KEM trait so that people can implement their own KEM. All of the newly exposed functions and fields are `#[doc(hidden)]` because this is really for power users.

Fixes #23 #25 #26

/cc @BoOTheFurious what do you think?