### PR TITLE
Remove unwrap

### DIFF
--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -19,7 +19,7 @@ use hpke::{
     aead::{AeadTag, ChaCha20Poly1305},
     kdf::HkdfSha384,
     kem::X25519HkdfSha256,
-    Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable,
+    Deserializable, HpkeError, Kem as KemTrait, OpModeR, OpModeS, Serializable,
 };
 
 use rand::{rngs::StdRng, SeedableRng};
@@ -32,7 +32,8 @@ type Aead = ChaCha20Poly1305;
 type Kdf = HkdfSha384;
 
 // Initializes the server with a fresh keypair
-fn server_init() -> (<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey) {
+fn server_init() -> Result<(<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey), HpkeError>
+{
     let mut csprng = StdRng::from_entropy();
     Kem::gen_keypair(&mut csprng)
 }
@@ -92,6 +93,7 @@ fn server_decrypt_msg(
         .expect("invalid ciphertext!");
 
     // Rename for clarity
+    #[allow(clippy::let_and_return)]
     let plaintext = ciphertext_copy;
 
     plaintext
@@ -99,7 +101,7 @@ fn server_decrypt_msg(
 
 fn main() {
     // Set up the server
-    let (server_privkey, server_pubkey) = server_init();
+    let (server_privkey, server_pubkey) = server_init().unwrap();
 
     // The message to be encrypted
     let msg = b"Kat Branchman";

--- a/src/dhkex.rs
+++ b/src/dhkex.rs
@@ -1,4 +1,4 @@
-use crate::{kdf::Kdf as KdfTrait, util::KemSuiteId, Deserializable, Serializable};
+use crate::{kdf::Kdf as KdfTrait, util::KemSuiteId, Deserializable, HpkeError, Serializable};
 
 #[cfg(feature = "serde_impls")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
@@ -64,7 +64,7 @@ pub trait DhKeyExchange {
     fn derive_keypair<Kdf: KdfTrait>(
         suite_id: &KemSuiteId,
         ikm: &[u8],
-    ) -> (Self::PrivateKey, Self::PublicKey);
+    ) -> Result<(Self::PrivateKey, Self::PublicKey), HpkeError>;
 }
 
 #[cfg(feature = "p256")]

--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -60,6 +60,7 @@ impl Serializable for PrivateKey {
         GenericArray::clone_from_slice(&self.0.to_bytes())
     }
 }
+
 impl Deserializable for PrivateKey {
     // Dalek lets us convert [u8; 32] to scalars. Assuming the input length is correct, this
     // conversion is infallible, so no ValidationErrors are raised.

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -141,7 +141,9 @@ where
         out: &mut [u8],
     ) -> Result<(), hkdf::InvalidLength> {
         // We need to write the length as a u16, so that's the de-facto upper bound on length
-        assert!(out.len() <= u16::MAX as usize);
+        if out.len() > u16::MAX as usize {
+            return Err(hkdf::InvalidLength);
+        }
 
         // Encode the output length in the info string
         let mut len_buf = [0u8; 2];

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -152,9 +152,8 @@ macro_rules! impl_dhkem {
                     // 255x the digest size of the hash function. Since these values are fixed at
                     // compile time, we don't worry about it.
                     let mut buf = <SharedSecret<$kem_name> as Default>::default();
-                    extract_and_expand::<$kdf>(concatted_secrets, &suite_id, kem_context, &mut buf.0)
-                        .expect("shared secret is way too big");
-                    buf
+                    extract_and_expand::<$kdf>(concatted_secrets, &suite_id, kem_context, &mut buf.0).map_err(|_| HpkeError::KdfOutputTooLong)?;
+                    Ok(buf)
                 } else {
                     // kem_context = encapped_key || pk_recip
                     // We concat without allocation by making a buffer of the maximum possible
@@ -176,10 +175,9 @@ macro_rules! impl_dhkem {
                         &suite_id,
                         kem_context,
                         &mut buf.0,
-                    )
-                    .expect("shared secret is way too big");
-                    buf
-                };
+                    ).map_err(|_| HpkeError::KdfOutputTooLong)?;
+                    Ok(buf)
+                }?;
 
                 Ok((shared_secret, encapped_key))
             }
@@ -310,7 +308,7 @@ macro_rules! impl_dhkem {
                             kem_context,
                             &mut shared_secret.0,
                         )
-                        .expect("shared secret is way too big");
+                        .map_err(|_| HpkeError::KdfOutputTooLong)?;
                         Ok(shared_secret)
                     } else {
                         // kem_context = encapped_key || pk_recip || pk_sender_id
@@ -334,7 +332,7 @@ macro_rules! impl_dhkem {
                             kem_context,
                             &mut shared_secret.0,
                         )
-                        .expect("shared secret is way too big");
+                        .map_err(|_| HpkeError::KdfOutputTooLong)?;
                         Ok(shared_secret)
                     }
                 }

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -207,7 +207,7 @@ macro_rules! impl_dhkem {
                 /// This keying material SHOULD have as many bits of entropy as the bit length of a
                 /// secret key, i.e., `8 * Self::PrivateKey::size()`. For X25519 and P-256, this is
                 /// 256 bits of entropy.
-                fn derive_keypair(ikm: &[u8]) -> (Self::PrivateKey, Self::PublicKey) {
+                fn derive_keypair(ikm: &[u8]) -> Result<(Self::PrivateKey, Self::PublicKey), HpkeError> {
                     let suite_id = kem_suite_id::<Self>();
                     <$dhkex as DhKeyExchange>::derive_keypair::<$kdf>(&suite_id, ikm)
                 }
@@ -219,7 +219,7 @@ macro_rules! impl_dhkem {
                     csprng: &mut R,
                 ) -> Result<(SharedSecret<Self>, Self::EncappedKey), HpkeError> {
                     // Generate a new ephemeral key
-                    let (sk_eph, _) = Self::gen_keypair(csprng);
+                    let (sk_eph, _) = Self::gen_keypair(csprng)?;
                     // Now pass to encap_with_eph()
                     encap_with_eph(pk_recip, sender_id_keypair, sk_eph)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
 //! type Kdf = HkdfSha384;
 //!
 //! let mut csprng = StdRng::from_entropy();
-//! # let (bob_sk, bob_pk) = Kem::gen_keypair(&mut csprng);
+//! # let (bob_sk, bob_pk) = Kem::gen_keypair(&mut csprng)
+//!     .unwrap(); // manage this error to avoid panic
 //!
 //! // This is a description string for the session. Both Alice and Bob need to know this value.
 //! // It's not secret.
@@ -142,8 +143,10 @@ use generic_array::{typenum::marker_traits::Unsigned, ArrayLength, GenericArray}
 /// Describes things that can go wrong in the HPKE protocol
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HpkeError {
-    /// The allowed number of message encryptions has been reached
+    /// the allowed number of message encryptions has been reached
     MessageLimitReached,
+    /// the allowed number of key derivation attempts has been reached
+    DerivationLimitReached,
     /// An error occurred while opening a ciphertext
     OpenError,
     /// An error occured while sealing a plaintext
@@ -165,6 +168,7 @@ impl core::fmt::Display for HpkeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             HpkeError::MessageLimitReached => write!(f, "Message limit reached"),
+            HpkeError::DerivationLimitReached => write!(f, "Key derivation limit reached"),
             HpkeError::OpenError => write!(f, "Failed to open ciphertext"),
             HpkeError::SealError => write!(f, "Failed to seal plaintext"),
             HpkeError::KdfOutputTooLong => write!(f, "Too many bytes requested from KDF"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! let mut csprng = StdRng::from_entropy();
 //! # let (bob_sk, bob_pk) = Kem::gen_keypair(&mut csprng)
-//!     .unwrap(); // manage this error to avoid panic
+//!     .expect("Key generation failed!");
 //!
 //! // This is a description string for the session. Both Alice and Bob need to know this value.
 //! // It's not secret.

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -137,10 +137,10 @@ mod test {
 
                 // Do a whole bunch of stuff to generate a valid session. All we care about is that
                 // this gives us a pubkey, secret key, and encapped key to test serde on
-                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
+                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng).unwrap();
                 let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
                 let (sender_mode, _) =
-                    new_op_mode_pair::<Kdf, Kem>(OpModeKind::Base, &psk, &psk_id);
+                    new_op_mode_pair::<Kdf, Kem>(OpModeKind::Base, &psk, &psk_id).unwrap();
                 let (encapped_key, mut aead_ctx) =
                     setup_sender::<A, Kdf, Kem, _>(&sender_mode, &pk_recip, &info[..], &mut csprng)
                         .unwrap();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -223,7 +223,7 @@ mod test {
                 let info = b"why would you think in a million years that that would actually work";
 
                 // Generate the receiver's long-term keypair
-                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
+                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng).unwrap();
 
                 // Try a full setup for all the op modes
                 for op_mode_kind in &[
@@ -235,7 +235,7 @@ mod test {
                     // Generate a mutually agreeing op mode pair
                     let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
                     let (sender_mode, receiver_mode) =
-                        new_op_mode_pair::<Kdf, Kem>(*op_mode_kind, &psk, &psk_id);
+                        new_op_mode_pair::<Kdf, Kem>(*op_mode_kind, &psk, &psk_id).unwrap();
 
                     // Construct the sender's encryption context, and get an encapped key
                     let (encapped_key, mut aead_ctx1) = setup_sender::<A, Kdf, Kem, _>(
@@ -276,12 +276,12 @@ mod test {
                 let info = b"why would you think in a million years that that would actually work";
 
                 // Generate the receiver's long-term keypair
-                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
+                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng).unwrap();
 
                 // Generate a mutually agreeing op mode pair
                 let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
                 let (sender_mode, receiver_mode) =
-                    new_op_mode_pair::<Kdf, Kem>(OpModeKind::Base, &psk, &psk_id);
+                    new_op_mode_pair::<Kdf, Kem>(OpModeKind::Base, &psk, &psk_id).unwrap();
 
                 // Construct the sender's encryption context normally
                 let (encapped_key, sender_ctx) =
@@ -302,7 +302,7 @@ mod test {
 
                 // Now make a receiver with the wrong secret key and ensure it doesn't match the
                 // sender
-                let (bad_sk, _) = Kem::gen_keypair(&mut csprng);
+                let (bad_sk, _) = Kem::gen_keypair(&mut csprng).unwrap();
                 let mut aead_ctx2 =
                     setup_receiver::<_, _, Kem>(&receiver_mode, &bad_sk, &encapped_key, &info[..])
                         .unwrap();

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -179,8 +179,8 @@ mod test {
                 };
 
                 // Generate the sender's and receiver's long-term keypairs
-                let (sk_sender_id, pk_sender_id) = Kem::gen_keypair(&mut csprng);
-                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
+                let (sk_sender_id, pk_sender_id) = Kem::gen_keypair(&mut csprng).unwrap();
+                let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng).unwrap();
 
                 // Construct the sender's encryption context, and get an encapped key
                 let sender_mode = OpModeS::<Kem>::AuthPsk(


### PR DESCRIPTION
Remove `unwrap()`, `expect()` and `panic!()` in trait implementations.

Correct Clippy warnings.