### PR TITLE
Delete misleading comment about feature `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ default = ["p256", "x25519"]
 x25519 = ["x25519-dalek"]
 # Include serde Serialize/Deserialize impls for all relevant types
 serde_impls = ["serde", "generic-array/serde"]
-# The std feature has no function outside of doing KAT tests. There is no need to use this in
-# production.
+# std includes an implementation of `std::error::Error` for `HpkeError`
 std = []
 
 [dependencies]


### PR DESCRIPTION
The comment in `Cargo.toml` suggests that feature `std` should never be
useful to clients, but in fact it turns on an `std::error::Error`
implementation, as noted in the README.