### PR TITLE
Update some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ serde_impls = ["serde", "generic-array/serde"]
 std = []
 
 [dependencies]
-aead = "0.4"
-aes-gcm = "0.9"
+aead = "0.5"
+aes-gcm = "0.10"
 byteorder = { version = "1.4", default-features = false }
-chacha20poly1305 = "0.9"
+chacha20poly1305 = "0.10"
 generic-array = { version = "0.14", default-features = false }
 digest = "0.10"
 hkdf = "0.12"
@@ -35,10 +35,10 @@ p256 = { version = "0.10", default-features = false, features = ["arithmetic", "
 sha2 = { version = "0.10", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.4", default-features = false }
-zeroize = { version = ">=1.3", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = ">=1.5", default-features = false, features = ["zeroize_derive"] }
 
 [dependencies.x25519-dalek]
-version = "1.2"
+version = "2.0.0-pre.1"
 default-features = false
 features = ["u64_backend"]
 optional = true

--- a/src/aead/export_only.rs
+++ b/src/aead/export_only.rs
@@ -1,6 +1,8 @@
 use crate::aead::Aead;
 
-use aead::{AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, NewAead as BaseNewAead};
+use aead::{
+    AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, KeyInit as BaseKeyInit, KeySizeUser,
+};
 use generic_array::typenum;
 
 /// An inert underlying Aead implementation. The open/seal routines panic. The `new()` function
@@ -38,9 +40,11 @@ impl BaseAeadInPlace for EmptyAeadImpl {
     }
 }
 
-impl BaseNewAead for EmptyAeadImpl {
+impl KeySizeUser for EmptyAeadImpl {
     type KeySize = typenum::U0;
+}
 
+impl BaseKeyInit for EmptyAeadImpl {
     // Ignore the key, since we can't encrypt or decrypt anything anyway. Just return the object
     fn new(_: &aead::Key<Self>) -> Self {
         EmptyAeadImpl


### PR DESCRIPTION
`chacha20` version `0.8.x` which is a dependency of `chacha20poly1305`
fails to run under miri and seems fixed by recent `0.9.x` series.