### PR TITLE
Updated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ serde_impls = ["serde", "generic-array/serde"]
 std = []
 
 [dependencies]
-aead = "0.4"
-aes-gcm = "0.10.0-pre"
+aead = "0.5"
+aes-gcm = "0.10"
 byteorder = { version = "1.4", default-features = false }
-chacha20poly1305 = "0.10.0-pre"
+chacha20poly1305 = "0.10"
 generic-array = { version = "0.14", default-features = false }
 digest = "0.10"
 hkdf = "0.12"
 hmac = "0.12"
 rand_core = { version = "0.6", default-features = false }
-p256 = { version = "0.10", default-features = false, features = ["arithmetic", "ecdh" ], optional = true}
+p256 = { version = "0.11", default-features = false, features = ["arithmetic", "ecdh" ], optional = true}
 sha2 = { version = "0.10", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ std = []
 
 [dependencies]
 aead = "0.4"
-aes-gcm = "0.9"
+aes-gcm = "0.10.0-pre"
 byteorder = { version = "1.4", default-features = false }
-chacha20poly1305 = "0.9"
+chacha20poly1305 = "0.10.0-pre"
 generic-array = { version = "0.14", default-features = false }
 digest = "0.10"
 hkdf = "0.12"
@@ -39,7 +39,7 @@ subtle = { version = "2.4", default-features = false }
 zeroize = { version = ">=1.3", default-features = false, features = ["zeroize_derive"] }
 
 [dependencies.x25519-dalek]
-version = "1.2"
+version = "2.0.0-pre.1"
 default-features = false
 features = ["u64_backend"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ p256 = { version = "0.11", default-features = false, features = ["arithmetic", "
 sha2 = { version = "0.10", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 subtle = { version = "2.4", default-features = false }
-zeroize = { version = ">=1.3", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dependencies.x25519-dalek]
 version = "2.0.0-pre.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ features = ["u64_backend"]
 optional = true
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.4", features = ["html_reports"] }
 hex = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/aead/export_only.rs
+++ b/src/aead/export_only.rs
@@ -1,6 +1,9 @@
 use crate::aead::Aead;
 
-use aead::{AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, NewAead as BaseNewAead};
+use aead::{
+    AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, KeyInit as BaseKeyInit,
+    KeySizeUser as BaseKeySizeUser,
+};
 use generic_array::typenum;
 
 /// An inert underlying Aead implementation. The open/seal routines panic. The `new()` function
@@ -38,9 +41,11 @@ impl BaseAeadInPlace for EmptyAeadImpl {
     }
 }
 
-impl BaseNewAead for EmptyAeadImpl {
+impl BaseKeySizeUser for EmptyAeadImpl {
     type KeySize = typenum::U0;
+}
 
+impl BaseKeyInit for EmptyAeadImpl {
     // Ignore the key, since we can't encrypt or decrypt anything anyway. Just return the object
     fn new(_: &aead::Key<Self>) -> Self {
         EmptyAeadImpl

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -88,7 +88,7 @@ impl Serializable for KexResult {
 
     fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
         // ecdh::SharedSecret::as_bytes returns the serialized x-coordinate
-        *self.0.as_bytes()
+        *self.0.raw_secret_bytes()
     }
 }
 


### PR DESCRIPTION
Updated the deps. Two things of note:

1. `zeroize` is now `^1` rather than `>= 1.3`. I'm just following this because [RustCrypto does this too](https://crates.io/crates/zeroize/reverse_dependencies).
2. `x25519-dalek` is now using a prerelease version `2.0.0-pre.1`. The only [changes here](https://github.com/dalek-cryptography/x25519-dalek/blob/3fc0108d7dee1c434158169f5a64b1f08e7bc12d/CHANGELOG.md) are in updated / loosening dependencies.