### PR TITLE
Made `Serializable::write_to_bytes` which writes to an output buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Pending
+
+* Added `Serializable::write_exact` so serialization requires less stack space
+
 ## [0.11.0] - 2023-10-11
 
 ### Removals

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -139,8 +139,18 @@ impl<A: Aead> Default for AeadTag<A> {
 impl<A: Aead> Serializable for AeadTag<A> {
     type OutputSize = <A::AeadImpl as BaseAeadCore>::TagSize;
 
-    fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
-        self.0.clone()
+    // Pass to underlying to_bytes() impl
+    fn write_to_bytes(&self, buf: &mut [u8]) {
+        let size = Self::size();
+        assert_eq!(
+            size,
+            buf.len(),
+            "serialized size ({}) does not match output buffer length ({})",
+            size,
+            buf.len()
+        );
+
+        buf.copy_from_slice(&self.0);
     }
 }
 

--- a/src/dhkex.rs
+++ b/src/dhkex.rs
@@ -74,12 +74,6 @@ pub trait DhKeyExchange {
 
 #[cfg(any(feature = "p256", feature = "p384"))]
 pub(crate) mod ecdh_nistp;
-#[cfg(feature = "p256")]
-pub use ecdh_nistp::p256::DhP256;
-#[cfg(feature = "p384")]
-pub use ecdh_nistp::p384::DhP384;
 
 #[cfg(feature = "x25519")]
 pub(crate) mod x25519;
-#[cfg(feature = "x25519")]
-pub use x25519::X25519;

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -106,7 +106,7 @@ macro_rules! nistp_dhkex {
                     );
 
                     // SecretKeys already know how to convert to bytes
-                    buf.copy_from_slice(&self.to_bytes());
+                    buf.copy_from_slice(&self.0.to_bytes());
                 }
             }
 

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -56,12 +56,22 @@ macro_rules! nistp_dhkex {
             impl Serializable for PublicKey {
                 type OutputSize = $pubkey_size;
 
-                fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+                fn write_to_bytes(&self, buf: &mut [u8]) {
+                    let size = Self::size();
+                    assert_eq!(
+                        size,
+                        buf.len(),
+                        "serialized size ({}) does not match output buffer length ({})",
+                        size,
+                        buf.len()
+                    );
+
                     // Get the uncompressed pubkey encoding
                     let encoded = self.0.as_affine().to_encoded_point(false);
                     // Serialize it
-                    GenericArray::clone_from_slice(encoded.as_bytes())
+                    buf.copy_from_slice(encoded.as_bytes());
                 }
+
             }
 
             // Everything is serialized and deserialized in uncompressed form
@@ -85,9 +95,18 @@ macro_rules! nistp_dhkex {
             impl Serializable for PrivateKey {
                 type OutputSize = $privkey_size;
 
-                fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+                fn write_to_bytes(&self, buf: &mut [u8]) {
+                    let size = Self::size();
+                    assert_eq!(
+                        size,
+                        buf.len(),
+                        "serialized size ({}) does not match output buffer length ({})",
+                        size,
+                        buf.len()
+                    );
+
                     // SecretKeys already know how to convert to bytes
-                    self.0.to_bytes()
+                    buf.copy_from_slice(&self.to_bytes());
                 }
             }
 
@@ -116,10 +135,19 @@ macro_rules! nistp_dhkex {
                 // resulting elliptic curve point.
                 type OutputSize = $ss_size;
 
-                fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+                fn write_to_bytes(&self, buf: &mut [u8]) {
+                    let size = Self::size();
+                    assert_eq!(
+                        size,
+                        buf.len(),
+                        "serialized size ({}) does not match output buffer length ({})",
+                        size,
+                        buf.len()
+                    );
+
                     // elliptic_curve::ecdh::SharedSecret::raw_secret_bytes returns the serialized
                     // x-coordinate
-                    *self.0.raw_secret_bytes()
+                    buf.copy_from_slice(self.0.raw_secret_bytes())
                 }
             }
 

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -15,7 +15,7 @@ macro_rules! nistp_dhkex {
             use crate::{
                 dhkex::{DhError, DhKeyExchange},
                 kdf::{labeled_extract, Kdf as KdfTrait, LabeledExpand},
-                util::{enforce_equal_len, KemSuiteId},
+                util::{enforce_equal_len, enforce_outbuf_len, KemSuiteId},
                 Deserializable, HpkeError, Serializable,
             };
 
@@ -56,15 +56,9 @@ macro_rules! nistp_dhkex {
             impl Serializable for PublicKey {
                 type OutputSize = $pubkey_size;
 
-                fn write_to_bytes(&self, buf: &mut [u8]) {
-                    let size = Self::size();
-                    assert_eq!(
-                        size,
-                        buf.len(),
-                        "serialized size ({}) does not match output buffer length ({})",
-                        size,
-                        buf.len()
-                    );
+                fn write_exact(&self, buf: &mut [u8]) {
+                    // Check the length is correct and panic if not
+                    enforce_outbuf_len::<Self>(buf);
 
                     // Get the uncompressed pubkey encoding
                     let encoded = self.0.as_affine().to_encoded_point(false);
@@ -95,15 +89,9 @@ macro_rules! nistp_dhkex {
             impl Serializable for PrivateKey {
                 type OutputSize = $privkey_size;
 
-                fn write_to_bytes(&self, buf: &mut [u8]) {
-                    let size = Self::size();
-                    assert_eq!(
-                        size,
-                        buf.len(),
-                        "serialized size ({}) does not match output buffer length ({})",
-                        size,
-                        buf.len()
-                    );
+                fn write_exact(&self, buf: &mut [u8]) {
+                    // Check the length is correct and panic if not
+                    enforce_outbuf_len::<Self>(buf);
 
                     // SecretKeys already know how to convert to bytes
                     buf.copy_from_slice(&self.0.to_bytes());
@@ -135,15 +123,9 @@ macro_rules! nistp_dhkex {
                 // resulting elliptic curve point.
                 type OutputSize = $ss_size;
 
-                fn write_to_bytes(&self, buf: &mut [u8]) {
-                    let size = Self::size();
-                    assert_eq!(
-                        size,
-                        buf.len(),
-                        "serialized size ({}) does not match output buffer length ({})",
-                        size,
-                        buf.len()
-                    );
+                fn write_exact(&self, buf: &mut [u8]) {
+                    // Check the length is correct and panic if not
+                    enforce_outbuf_len::<Self>(buf);
 
                     // elliptic_curve::ecdh::SharedSecret::raw_secret_bytes returns the serialized
                     // x-coordinate

--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -5,10 +5,7 @@ use crate::{
     Deserializable, HpkeError, Serializable,
 };
 
-use generic_array::{
-    typenum::{self, Unsigned},
-    GenericArray,
-};
+use generic_array::typenum::{self, Unsigned};
 use subtle::{Choice, ConstantTimeEq};
 
 // We wrap the types in order to abstract away the dalek dep
@@ -46,8 +43,17 @@ impl Serializable for PublicKey {
     type OutputSize = typenum::U32;
 
     // Dalek lets us convert pubkeys to [u8; 32]
-    fn to_bytes(&self) -> GenericArray<u8, typenum::U32> {
-        GenericArray::clone_from_slice(self.0.as_bytes())
+    fn write_to_bytes(&self, buf: &mut [u8]) {
+        let size = Self::size();
+        assert_eq!(
+            size,
+            buf.len(),
+            "serialized size ({}) does not match output buffer length ({})",
+            size,
+            buf.len()
+        );
+
+        buf.copy_from_slice(self.0.as_bytes());
     }
 }
 
@@ -70,8 +76,17 @@ impl Serializable for PrivateKey {
     type OutputSize = typenum::U32;
 
     // Dalek lets us convert scalars to [u8; 32]
-    fn to_bytes(&self) -> GenericArray<u8, typenum::U32> {
-        GenericArray::clone_from_slice(&self.0.to_bytes())
+    fn write_to_bytes(&self, buf: &mut [u8]) {
+        let size = Self::size();
+        assert_eq!(
+            size,
+            buf.len(),
+            "serialized size ({}) does not match output buffer length ({})",
+            size,
+            buf.len()
+        );
+
+        buf.copy_from_slice(self.0.as_bytes());
     }
 }
 impl Deserializable for PrivateKey {
@@ -102,9 +117,18 @@ impl Serializable for KexResult {
     type OutputSize = typenum::U32;
 
     // curve25519's point representation is our DH result. We don't have to do anything special.
-    fn to_bytes(&self) -> GenericArray<u8, typenum::U32> {
+    fn write_to_bytes(&self, buf: &mut [u8]) {
+        let size = Self::size();
+        assert_eq!(
+            size,
+            buf.len(),
+            "serialized size ({}) does not match output buffer length ({})",
+            size,
+            buf.len()
+        );
+
         // Dalek lets us convert shared secrets to to [u8; 32]
-        GenericArray::clone_from_slice(self.0.as_bytes())
+        buf.copy_from_slice(self.0.as_bytes());
     }
 }
 

--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -1,7 +1,7 @@
 use crate::{
     dhkex::{DhError, DhKeyExchange},
     kdf::{labeled_extract, Kdf as KdfTrait, LabeledExpand},
-    util::{enforce_equal_len, KemSuiteId},
+    util::{enforce_equal_len, enforce_outbuf_len, KemSuiteId},
     Deserializable, HpkeError, Serializable,
 };
 
@@ -43,15 +43,9 @@ impl Serializable for PublicKey {
     type OutputSize = typenum::U32;
 
     // Dalek lets us convert pubkeys to [u8; 32]
-    fn write_to_bytes(&self, buf: &mut [u8]) {
-        let size = Self::size();
-        assert_eq!(
-            size,
-            buf.len(),
-            "serialized size ({}) does not match output buffer length ({})",
-            size,
-            buf.len()
-        );
+    fn write_exact(&self, buf: &mut [u8]) {
+        // Check the length is correct and panic if not
+        enforce_outbuf_len::<Self>(buf);
 
         buf.copy_from_slice(self.0.as_bytes());
     }
@@ -76,15 +70,9 @@ impl Serializable for PrivateKey {
     type OutputSize = typenum::U32;
 
     // Dalek lets us convert scalars to [u8; 32]
-    fn write_to_bytes(&self, buf: &mut [u8]) {
-        let size = Self::size();
-        assert_eq!(
-            size,
-            buf.len(),
-            "serialized size ({}) does not match output buffer length ({})",
-            size,
-            buf.len()
-        );
+    fn write_exact(&self, buf: &mut [u8]) {
+        // Check the length is correct and panic if not
+        enforce_outbuf_len::<Self>(buf);
 
         buf.copy_from_slice(self.0.as_bytes());
     }
@@ -117,15 +105,9 @@ impl Serializable for KexResult {
     type OutputSize = typenum::U32;
 
     // curve25519's point representation is our DH result. We don't have to do anything special.
-    fn write_to_bytes(&self, buf: &mut [u8]) {
-        let size = Self::size();
-        assert_eq!(
-            size,
-            buf.len(),
-            "serialized size ({}) does not match output buffer length ({})",
-            size,
-            buf.len()
-        );
+    fn write_exact(&self, buf: &mut [u8]) {
+        // Check the length is correct and panic if not
+        enforce_outbuf_len::<Self>(buf);
 
         // Dalek lets us convert shared secrets to to [u8; 32]
         buf.copy_from_slice(self.0.as_bytes());

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -15,7 +15,7 @@ macro_rules! impl_dhkem {
                 dhkex::{DhKeyExchange, MAX_PUBKEY_SIZE},
                 kdf::{extract_and_expand, Kdf as KdfTrait},
                 kem::{Kem as KemTrait, SharedSecret},
-                util::kem_suite_id,
+                util::{enforce_outbuf_len, kem_suite_id},
                 Deserializable, HpkeError, Serializable,
             };
 
@@ -45,13 +45,9 @@ macro_rules! impl_dhkem {
                 type OutputSize = <<$dhkex as DhKeyExchange>::PublicKey as Serializable>::OutputSize;
 
                 // Pass to underlying to_bytes() impl
-                fn write_to_bytes(&self, buf: &mut [u8]) {
-                    let size = Self::size();
-                    assert_eq!(
-                        size, buf.len(),
-                        "serialized size ({}) does not match output buffer length ({})",
-                        size, buf.len()
-                    );
+                fn write_exact(&self, buf: &mut [u8]) {
+                    // Check the length is correct and panic if not
+                    enforce_outbuf_len::<Self>(buf);
 
                     buf.copy_from_slice(&self.0.to_bytes());
                 }

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -20,7 +20,6 @@ macro_rules! impl_dhkem {
             };
 
             use digest::OutputSizeUser;
-            use generic_array::GenericArray;
             use rand_core::{CryptoRng, RngCore};
 
             // Define convenience types
@@ -46,8 +45,15 @@ macro_rules! impl_dhkem {
                 type OutputSize = <<$dhkex as DhKeyExchange>::PublicKey as Serializable>::OutputSize;
 
                 // Pass to underlying to_bytes() impl
-                fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
-                    self.0.to_bytes()
+                fn write_to_bytes(&self, buf: &mut [u8]) {
+                    let size = Self::size();
+                    assert_eq!(
+                        size, buf.len(),
+                        "serialized size ({}) does not match output buffer length ({})",
+                        size, buf.len()
+                    );
+
+                    buf.copy_from_slice(&self.0.to_bytes());
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,10 @@ pub trait Serializable {
     type OutputSize: ArrayLength<u8>;
 
     fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+        // Make a buffer of the correct size and write to it
         let mut buf = GenericArray::default();
         self.write_to_bytes(&mut buf);
+        // Return the buffer
         buf
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,20 +189,24 @@ impl core::fmt::Display for HpkeError {
 
 /// Implemented by types that have a fixed-length byte representation
 pub trait Serializable {
+    /// Serialized size in bytes
     type OutputSize: ArrayLength<u8>;
 
+    /// Serializes `self` to the given slice. `buf` MUST have length equal to `Self::size()`.
+    ///
+    /// Panics
+    /// ======
+    /// Panics if `buf.len() != Self::size()`.
+    fn write_exact(&self, buf: &mut [u8]);
+
+    /// Serializes `self` to a new array
     fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
         // Make a buffer of the correct size and write to it
         let mut buf = GenericArray::default();
-        self.write_to_bytes(&mut buf);
+        self.write_exact(&mut buf);
         // Return the buffer
         buf
     }
-
-    /// Writes the data to the given slice. `buf` must have length `Self::size()`.
-    ///
-    /// **Panics** if `buf.len() != Self::size()`.
-    fn write_to_bytes(&self, buf: &mut [u8]);
 
     /// Returns the size (in bytes) of this type when serialized
     fn size() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,16 @@ impl core::fmt::Display for HpkeError {
 pub trait Serializable {
     type OutputSize: ArrayLength<u8>;
 
-    fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize>;
+    fn to_bytes(&self) -> GenericArray<u8, Self::OutputSize> {
+        let mut buf = GenericArray::default();
+        self.write_to_bytes(&mut buf);
+        buf
+    }
+
+    /// Writes the data to the given slice. `buf` must have length `Self::size()`.
+    ///
+    /// **Panics** if `buf.len() != Self::size()`.
+    fn write_to_bytes(&self, buf: &mut [u8]);
 
     /// Returns the size (in bytes) of this type when serialized
     fn size() -> usize {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::{aead::Aead, kdf::Kdf as KdfTrait, kem::Kem as KemTrait, HpkeError};
+use crate::{aead::Aead, kdf::Kdf as KdfTrait, kem::Kem as KemTrait, HpkeError, Serializable};
 
 use byteorder::{BigEndian, ByteOrder};
 
@@ -92,4 +92,17 @@ pub(crate) fn enforce_equal_len(expected_len: usize, given_len: usize) -> Result
     } else {
         Ok(())
     }
+}
+
+/// Helper function for `Serializable::write_exact`. Takes a buffer and a serializable type `T` and
+/// panics iff `buf.len() != T::size()`.
+pub(crate) fn enforce_outbuf_len<T: Serializable>(buf: &[u8]) {
+    let size = T::size();
+    let buf_len = buf.len();
+    assert!(
+        size == buf_len,
+        "write_exact(): serialized size ({}) does not equal buffer length ({})",
+        size,
+        buf_len,
+    );
 }


### PR DESCRIPTION
I took a shot at implementing something simple to resolve #44. We restrict the API to writing to buffers that are already of the correct size. We can do this because the size of everything `Serializable` is known in advance.

Questions:
1. Is it reasonable to assume that we can always write to memory? I think the answer should be yes. I cannot imagine any pubkey or ciphertext is so large that it must be written straight to disk or network.
2. I couldn't think of a better name than `write_to_bytes`. Does that sound reasonable? What about just `write`?

Finally, this isn't immediately backportable to the xyber branch, so that'll be a separate PR.

/cc @wucke13 @tarcieri