### PR TITLE
Proposed API change: accept key material by reference

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -50,15 +50,15 @@ where
     let opmodes = ["base", "auth", "psk", "authpsk"];
     let opmodes_s = vec![
         OpModeS::Base,
-        OpModeS::Auth((sk_sender.clone(), pk_sender.clone())),
+        OpModeS::Auth((&sk_sender, &pk_sender)),
         OpModeS::Psk(psk_bundle),
-        OpModeS::AuthPsk((sk_sender, pk_sender.clone()), psk_bundle),
+        OpModeS::AuthPsk((&sk_sender, &pk_sender), psk_bundle),
     ];
     let opmodes_r = vec![
         OpModeR::Base,
         OpModeR::Psk(psk_bundle),
-        OpModeR::Auth(pk_recip.clone()),
-        OpModeR::AuthPsk(pk_recip.clone(), psk_bundle),
+        OpModeR::Auth(&pk_recip),
+        OpModeR::AuthPsk(&pk_recip, psk_bundle),
     ];
 
     // Bench setup_sender() for each opmode

--- a/src/op_mode.rs
+++ b/src/op_mode.rs
@@ -26,9 +26,9 @@ pub enum OpModeR<'a, Kem: KemTrait> {
     /// A preshared key known to the sender and receiver
     Psk(PskBundle<'a>),
     /// The identity public key of the sender
-    Auth(Kem::PublicKey),
+    Auth(&'a Kem::PublicKey),
     /// Both of the above
-    AuthPsk(Kem::PublicKey, PskBundle<'a>),
+    AuthPsk(&'a Kem::PublicKey, PskBundle<'a>),
 }
 
 // Helper function for setup_receiver
@@ -53,9 +53,9 @@ pub enum OpModeS<'a, Kem: KemTrait> {
     /// A preshared key known to the sender and receiver
     Psk(PskBundle<'a>),
     /// The identity keypair of the sender
-    Auth((Kem::PrivateKey, Kem::PublicKey)),
+    Auth((&'a Kem::PrivateKey, &'a Kem::PublicKey)),
     /// Both of the above
-    AuthPsk((Kem::PrivateKey, Kem::PublicKey), PskBundle<'a>),
+    AuthPsk((&'a Kem::PrivateKey, &'a Kem::PublicKey), PskBundle<'a>),
 }
 
 // Helpers functions for setup_sender and testing

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -234,8 +234,9 @@ mod test {
                 ] {
                     // Generate a mutually agreeing op mode pair
                     let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
+                    let key_pair = Kem::gen_keypair(&mut csprng);
                     let (sender_mode, receiver_mode) =
-                        new_op_mode_pair::<Kdf, Kem>(*op_mode_kind, &psk, &psk_id);
+                        new_op_mode_pair::<Kdf, Kem>(&key_pair, *op_mode_kind, &psk, &psk_id);
 
                     // Construct the sender's encryption context, and get an encapped key
                     let (encapped_key, mut aead_ctx1) = setup_sender::<A, Kdf, Kem, _>(
@@ -280,8 +281,9 @@ mod test {
 
                 // Generate a mutually agreeing op mode pair
                 let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
+                let key_pair = Kem::gen_keypair(&mut csprng);
                 let (sender_mode, receiver_mode) =
-                    new_op_mode_pair::<Kdf, Kem>(OpModeKind::Base, &psk, &psk_id);
+                    new_op_mode_pair::<Kdf, Kem>(&key_pair, OpModeKind::Base, &psk, &psk_id);
 
                 // Construct the sender's encryption context normally
                 let (encapped_key, sender_ctx) =

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -187,13 +187,11 @@ mod test {
                 let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
 
                 // Construct the sender's encryption context, and get an encapped key
-                let sender_mode = OpModeS::<Kem>::AuthPsk(
-                    (sk_sender_id, pk_sender_id.clone()),
-                    psk_bundle.clone(),
-                );
+                let sender_mode =
+                    OpModeS::<Kem>::AuthPsk((&sk_sender_id, &pk_sender_id), psk_bundle.clone());
 
                 // Use the encapped key to derive the reciever's encryption context
-                let receiver_mode = OpModeR::<Kem>::AuthPsk(pk_sender_id, psk_bundle);
+                let receiver_mode = OpModeR::<Kem>::AuthPsk(&pk_sender_id, psk_bundle);
 
                 // Encrypt with the first context
                 let (encapped_key, ciphertext) = single_shot_seal::<A, Kdf, Kem, _>(

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -74,12 +74,11 @@ pub(crate) enum OpModeKind {
 
 /// Makes an agreeing pair of `OpMode`s of the specified variant
 pub(crate) fn new_op_mode_pair<'a, Kdf: KdfTrait, Kem: KemTrait>(
+    (sk_sender, pk_sender): &'a (<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey),
     kind: OpModeKind,
     psk: &'a [u8],
     psk_id: &'a [u8],
 ) -> (OpModeS<'a, Kem>, OpModeR<'a, Kem>) {
-    let mut csprng = StdRng::from_entropy();
-    let (sk_sender, pk_sender) = Kem::gen_keypair(&mut csprng);
     let psk_bundle = PskBundle { psk, psk_id };
 
     match kind {
@@ -94,12 +93,12 @@ pub(crate) fn new_op_mode_pair<'a, Kdf: KdfTrait, Kem: KemTrait>(
             (sender_mode, receiver_mode)
         }
         OpModeKind::Auth => {
-            let sender_mode = OpModeS::Auth((sk_sender, pk_sender.clone()));
+            let sender_mode = OpModeS::Auth((sk_sender, pk_sender));
             let receiver_mode = OpModeR::Auth(pk_sender);
             (sender_mode, receiver_mode)
         }
         OpModeKind::AuthPsk => {
-            let sender_mode = OpModeS::AuthPsk((sk_sender, pk_sender.clone()), psk_bundle);
+            let sender_mode = OpModeS::AuthPsk((sk_sender, pk_sender), psk_bundle);
             let receiver_mode = OpModeR::AuthPsk(pk_sender, psk_bundle);
             (sender_mode, receiver_mode)
         }


### PR DESCRIPTION
Thank you for this useful library!

I noticed while using the library that the interface forces the caller to transfer memory ownership of the key material to an instance of the operation mode enum (`OpModeS`).

Since the PSK is also part of this data structure, one cannot reuse the `OpModeS::AuthPsk` value for multiple sessions and is thus forced to clone the private / public key for each PSK /  `OpModeS::AuthPsk` instance.

The API can be changed to take a reference to the key material; see this PR as an example.

Would you consider such a change to the API? I could assist in updating examples and documentation.