### PR TITLE
Force Aead::AeadImpl to be Send + Sync

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -19,7 +19,7 @@ use zeroize::Zeroize;
 pub trait Aead {
     /// The underlying AEAD implementation
     #[doc(hidden)]
-    type AeadImpl: BaseAeadCore + BaseAeadInPlace + BaseKeyInit + Clone;
+    type AeadImpl: BaseAeadCore + BaseAeadInPlace + BaseKeyInit + Clone + Send + Sync;
 
     /// The algorithm identifier for an AEAD implementation
     const AEAD_ID: u16;


### PR DESCRIPTION
When trying to use AeadCtxR/AeadCtxS in a generic context which requires Send or Sync, downstream users need to add a bound to Aead::AeadImpl even though this is a doc(hidden) item and thus an implementation detail that may change afterwards.

All implementations of Aead provide an AeadImpl type that is already Send + Sync so it doesn't hurt to add a trait bound there.