### PR TITLE
Made clippy happy

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -8,7 +8,7 @@ use crate::{
     Deserializable, HpkeError, Serializable,
 };
 
-use core::{default::Default, marker::PhantomData, u8};
+use core::{default::Default, marker::PhantomData};
 
 use aead::{AeadCore as BaseAeadCore, AeadInPlace as BaseAeadInPlace, KeyInit as BaseKeyInit};
 use byteorder::{BigEndian, ByteOrder};


### PR DESCRIPTION
I think a new lint popped up in the last few weeks, so it wasn't caught by the old CI run.

```
error: importing legacy numeric constants
  --> src/aead.rs:11:51
   |
11 | use core::{default::Default, marker::PhantomData, u8};
   |                                                   ^^
   |
   = help: remove this import
   = note: then `u8::<CONST>` will resolve to the respective associated constant
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
   = note: `-D clippy::legacy-numeric-constants` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::legacy_numeric_constants)]`
```