### PR TITLE
Upgrade rand and rand_core to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,22 +33,38 @@ generic-array = { version = "0.14", default-features = false }
 digest = "0.10"
 hkdf = "0.12"
 hmac = "0.12"
-rand_core = { version = "0.6", default-features = false }
-p256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"], optional = true}
-p384 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"], optional = true}
-p521 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdh"], optional = true}
+rand_core = { version = "0.9", default-features = false }
+p256 = { version = "0.13", default-features = false, features = [
+    "arithmetic",
+    "ecdh",
+], optional = true }
+p384 = { version = "0.13", default-features = false, features = [
+    "arithmetic",
+    "ecdh",
+], optional = true }
+p521 = { version = "0.13", default-features = false, features = [
+    "arithmetic",
+    "ecdh",
+], optional = true }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.6", default-features = false }
-x25519-dalek = { version = "2", default-features = false, features = ["static_secrets"], optional = true }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+x25519-dalek = { version = "2", default-features = false, features = [
+    "static_secrets",
+], optional = true }
+zeroize = { version = "1", default-features = false, features = [
+    "zeroize_derive",
+] }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4"
 hex-literal = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"] }
+rand = { version = "0.9", default-features = false, features = [
+    "os_rng",
+    "std_rng",
+] }
 
 [[example]]
 name = "client_server"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -23,7 +23,7 @@ where
     Kdf: KdfTrait,
     Kem: KemTrait,
 {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     let mut group = c.benchmark_group(group_name);
 
@@ -171,7 +171,7 @@ where
     Kdf: KdfTrait,
     Kem: KemTrait,
 {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     // Make up the recipient's keypair and setup an encryption context
     let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);

--- a/examples/agility.rs
+++ b/examples/agility.rs
@@ -675,7 +675,7 @@ fn agile_setup_receiver(
 }
 
 fn main() {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     let supported_aead_algs = &[
         AeadAlg::AesGcm128,

--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -33,7 +33,7 @@ type Kdf = HkdfSha384;
 
 // Initializes the server with a fresh keypair
 fn server_init() -> (<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey) {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
     Kem::gen_keypair(&mut csprng)
 }
 
@@ -44,7 +44,7 @@ fn client_encrypt_msg(
     associated_data: &[u8],
     server_pk: &<Kem as KemTrait>::PublicKey,
 ) -> (<Kem as KemTrait>::EncappedKey, Vec<u8>, AeadTag<Aead>) {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     // Encapsulate a key and use the resulting shared secret to encrypt a message. The AEAD context
     // is what you use to encrypt.

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -422,7 +422,7 @@ mod tests {
     /// Tests that an deserialize-serialize round-trip ends up at the same pubkey
     #[allow(dead_code)]
     fn test_pubkey_serialize_correctness<Kex: DhKeyExchange>() {
-        let mut csprng = StdRng::from_entropy();
+        let mut csprng = StdRng::from_os_rng();
 
         // We can't do the same thing as in the X25519 tests, since a completely random point
         // is not likely to lie on the curve. Instead, we just generate a random point,
@@ -459,7 +459,7 @@ mod tests {
     where
         Kex::PrivateKey: PartialEq,
     {
-        let mut csprng = StdRng::from_entropy();
+        let mut csprng = StdRng::from_os_rng();
 
         // Make a random keypair and serialize it
         let (sk, pk) = dhkex_gen_keypair::<Kex, _>(&mut csprng);

--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -186,7 +186,7 @@ mod tests {
     fn test_pubkey_serialize_correctness() {
         type Kex = X25519;
 
-        let mut csprng = StdRng::from_entropy();
+        let mut csprng = StdRng::from_os_rng();
 
         // Fill a buffer with randomness
         let orig_bytes = {
@@ -210,7 +210,7 @@ mod tests {
     fn test_dh_serialize_correctness() {
         type Kex = X25519;
 
-        let mut csprng = StdRng::from_entropy();
+        let mut csprng = StdRng::from_os_rng();
 
         // Make a random keypair and serialize it
         let (sk, pk) = dhkex_gen_keypair::<Kex, _>(&mut csprng);

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -123,7 +123,7 @@ mod tests {
             fn $test_name() {
                 type Kem = $kem_ty;
 
-                let mut csprng = StdRng::from_entropy();
+                let mut csprng = StdRng::from_os_rng();
                 let (sk_recip, pk_recip) = Kem::gen_keypair(&mut csprng);
 
                 // Encapsulate a random shared secret
@@ -171,7 +171,7 @@ mod tests {
 
                 // Encapsulate a random shared secret
                 let encapped_key = {
-                    let mut csprng = StdRng::from_entropy();
+                    let mut csprng = StdRng::from_os_rng();
                     let (_, pk_recip) = Kem::gen_keypair(&mut csprng);
                     Kem::encap(&pk_recip, None, &mut csprng).unwrap().1
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! type Aead = ChaCha20Poly1305;
 //! type Kdf = HkdfSha384;
 //!
-//! let mut csprng = StdRng::from_entropy();
+//! let mut csprng = StdRng::from_os_rng();
 //! # let (bob_sk, bob_pk) = Kem::gen_keypair(&mut csprng);
 //!
 //! // This is a description string for the session. Both Alice and Bob need to know this value.

--- a/src/op_mode.rs
+++ b/src/op_mode.rs
@@ -32,7 +32,7 @@ pub enum OpModeR<'a, Kem: KemTrait> {
 }
 
 // Helper function for setup_receiver
-impl<'a, Kem: KemTrait> OpModeR<'a, Kem> {
+impl<Kem: KemTrait> OpModeR<'_, Kem> {
     /// Returns the sender's identity pubkey if it's specified
     pub(crate) fn get_pk_sender_id(&self) -> Option<&Kem::PublicKey> {
         match self {
@@ -59,7 +59,7 @@ pub enum OpModeS<'a, Kem: KemTrait> {
 }
 
 // Helpers functions for setup_sender and testing
-impl<'a, Kem: KemTrait> OpModeS<'a, Kem> {
+impl<Kem: KemTrait> OpModeS<'_, Kem> {
     /// Returns the sender's identity pubkey if it's specified
     pub(crate) fn get_sender_id_keypair(&self) -> Option<(&Kem::PrivateKey, &Kem::PublicKey)> {
         match self {
@@ -81,7 +81,7 @@ pub(crate) trait OpMode<Kem: KemTrait> {
     fn get_psk_id(&self) -> &[u8];
 }
 
-impl<'a, Kem: KemTrait> OpMode<Kem> for OpModeR<'a, Kem> {
+impl<Kem: KemTrait> OpMode<Kem> for OpModeR<'_, Kem> {
     // Defined in RFC 9180 §5 Table 1
     fn mode_id(&self) -> u8 {
         match self {
@@ -116,7 +116,7 @@ impl<'a, Kem: KemTrait> OpMode<Kem> for OpModeR<'a, Kem> {
 
 // I know there's a bunch of code reuse here, but it's not so much that I feel the need to abstract
 // something away
-impl<'a, Kem: KemTrait> OpMode<Kem> for OpModeS<'a, Kem> {
+impl<Kem: KemTrait> OpMode<Kem> for OpModeS<'_, Kem> {
     // Defined in RFC 9180 §5 Table 1
     fn mode_id(&self) -> u8 {
         match self {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -218,7 +218,7 @@ mod test {
                 type Kdf = $kdf_ty;
                 type Kem = $kem_ty;
 
-                let mut csprng = StdRng::from_entropy();
+                let mut csprng = StdRng::from_os_rng();
 
                 let info = b"why would you think in a million years that that would actually work";
 
@@ -271,7 +271,7 @@ mod test {
                 type Kdf = $kdf;
                 type Kem = $kem;
 
-                let mut csprng = StdRng::from_entropy();
+                let mut csprng = StdRng::from_os_rng();
 
                 let info = b"why would you think in a million years that that would actually work";
 

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -172,7 +172,7 @@ mod test {
                 let msg = b"Good night, a-ding ding ding ding ding";
                 let aad = b"Five four three two one";
 
-                let mut csprng = StdRng::from_entropy();
+                let mut csprng = StdRng::from_os_rng();
 
                 // Set up an arbitrary info string, a random PSK, and an arbitrary PSK ID
                 let info = b"why would you think in a million years that that would actually work";

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -13,7 +13,7 @@ use rand::{rngs::StdRng, CryptoRng, Rng, RngCore, SeedableRng};
 
 /// Returns a random 32-byte buffer
 pub(crate) fn gen_rand_buf() -> [u8; 32] {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
     let mut buf = [0u8; 32];
     csprng.fill_bytes(&mut buf);
     buf
@@ -39,7 +39,7 @@ where
     Kdf: KdfTrait,
     Kem: KemTrait,
 {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     // Initialize the key and nonce
     let key = {
@@ -78,7 +78,7 @@ pub(crate) fn new_op_mode_pair<'a, Kdf: KdfTrait, Kem: KemTrait>(
     psk: &'a [u8],
     psk_id: &'a [u8],
 ) -> (OpModeS<'a, Kem>, OpModeR<'a, Kem>) {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
     let (sk_sender, pk_sender) = Kem::gen_keypair(&mut csprng);
     let psk_bundle = PskBundle { psk, psk_id };
 
@@ -112,16 +112,16 @@ pub(crate) fn aead_ctx_eq<A: Aead, Kdf: KdfTrait, Kem: KemTrait>(
     sender: &mut AeadCtxS<A, Kdf, Kem>,
     receiver: &mut AeadCtxR<A, Kdf, Kem>,
 ) -> bool {
-    let mut csprng = StdRng::from_entropy();
+    let mut csprng = StdRng::from_os_rng();
 
     // Some random input data
-    let msg_len = csprng.gen::<u8>() as usize;
+    let msg_len = csprng.random::<u8>() as usize;
     let msg_buf = {
         let mut buf = [0u8; 255];
         csprng.fill_bytes(&mut buf);
         buf
     };
-    let aad_len = csprng.gen::<u8>() as usize;
+    let aad_len = csprng.random::<u8>() as usize;
     let aad_buf = {
         let mut buf = [0u8; 255];
         csprng.fill_bytes(&mut buf);


### PR DESCRIPTION
This is related when I'm trying to bump rand/rand_core in https://github.com/RustCrypto/traits and it's blocked by this transitive dependency.