### PR TITLE
Don't copy the scalar bytes for the comparison of private X25519 keys

### DIFF
--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -21,8 +21,8 @@ pub struct PrivateKey(x25519_dalek::StaticSecret);
 
 impl ConstantTimeEq for PrivateKey {
     fn ct_eq(&self, other: &Self) -> Choice {
-        // We can use to_bytes because StaticSecret is only ever constructed from a clamped scalar
-        self.0.to_bytes().ct_eq(&other.0.to_bytes())
+        // We can use as_bytes because StaticSecret is only ever constructed from a clamped scalar
+        self.0.as_bytes().ct_eq(other.0.as_bytes())
     }
 }
 


### PR DESCRIPTION
Calling StaticSecret::to_bytes() creates a copy of the bytes containing the secret key material.

This happens because to_bytes(), by returning the array of bytes, moves them out of the function. Moving a value in Rust compiles down into a memory copy. This unintended copy of the secret key material will not be zeroized once dropped.

Luckily a StaticSecret::as_bytes() exists which operates on references. By using as_bytes(), only the references to the secret key material will be copied. As ct_eq() operates on references anyways, this is a simple drop-in replacement.

This issue is described in more detail here:
    https://benma.github.io/2020/10/16/rust-zeroize-move.html