### PR TITLE
Simplify feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           targets: thumbv6m-none-eabi
       - name: Build with all features but kat and getrandom
-        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "alloc,x25519,nistp,mlkem,aes,chacha,hkdf,shake"
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "alloc,x25519,nistp,mlkem,aes,chacha,hkdfsha2,shake"
       - name: Build with no default features
         run: cargo build --target thumbv6m-none-eabi --no-default-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,11 @@ jobs:
           RUSTFLAGS: -D warnings -A dead_code -A unused_imports
         run: cargo test --no-default-features --features="x25519,chacha"
 
-      - name: Run cargo test with P256 and ChaCha20-Poly1305
+      - name: Run cargo test with NIST-P curves and ChaCha20-Poly1305
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings -A dead_code -A unused_imports
-        run: cargo test --no-default-features --features="p256,chacha"
-
-      - name: Run cargo test with P384 and ChaCha20-Poly1305
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings -A dead_code -A unused_imports
-        run: cargo test --no-default-features --features="p384,chacha"
-
-      - name: Run cargo test with P521 and ChaCha20-Poly1305
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings -A dead_code -A unused_imports
-        run: cargo test --no-default-features --features="p521,chacha"
+        run: cargo test --no-default-features --features="nistp,chacha"
 
       - name: Run cargo test with X25519 and AES-GCM
         env:
@@ -60,11 +48,17 @@ jobs:
           RUSTFLAGS: -D warnings -A dead_code -A unused_imports
         run: cargo test --no-default-features --features="x25519,aes"
 
-      - name: Run cargo test with P256 and AES-GCM
+      - name: Run cargo test with NIST-P curves and AES-GCM
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings -A dead_code -A unused_imports
-        run: cargo test --no-default-features --features="p256,aes"
+        run: cargo test --no-default-features --features="nistp,aes"
+
+      - name: Run cargo test with ML-KEM and ChaCha20-Poly1305
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings -A dead_code -A unused_imports
+        run: cargo test --no-default-features --features="mlkem,chacha"
 
       - name: Run cargo test with all features enabled
         env:
@@ -138,7 +132,7 @@ jobs:
         with:
           targets: thumbv6m-none-eabi
       - name: Build with all features but kat and getrandom
-        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "x25519,p256,p384,p521,xwing,aes,chacha"
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "alloc,x25519,nistp,mlkem,aes,chacha,hkdf,shake"
       - name: Build with no default features
         run: cargo build --target thumbv6m-none-eabi --no-default-features
 
@@ -157,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build just MLKEM768 and make sure we have no dead code
-        run: cargo build --no-default-features --features "mlkem768"
+      - name: Build just ML-KEM and make sure we have no dead code
+        run: cargo build --no-default-features --features "mlkem"
         env:
           RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Build with all features but kat and getrandom
         run: cargo build --target thumbv6m-none-eabi --no-default-features --features "alloc,x25519,nistp,mlkem,aes,chacha,hkdfsha2,shake"
       - name: Build with no default features
-        run: cargo build --target thumbv6m-none-eabi --no-default-features
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "x25519,chacha"
 
   kat:
     name: Known-answer test build
@@ -152,6 +152,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Build just ML-KEM and make sure we have no dead code
-        run: cargo build --no-default-features --features "mlkem"
+        run: cargo build --no-default-features --features "mlkem,chacha"
         env:
           RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,19 @@ rust-version = "1.85"
 
 [features]
 default = ["getrandom", "alloc", "x25519", "mlkem", "chacha"]
-x25519 = ["dep:x25519-dalek", "hkdf"]
-nistp = ["dep:p256", "dep:p384", "dep:p521", "hkdf"]
+x25519 = ["dep:x25519-dalek", "hkdfsha2"]
+nistp = ["dep:p256", "dep:p384", "dep:p521", "hkdfsha2"]
 mlkem = ["dep:ml-kem", "dep:x-wing", "shake"]
 aes = ["dep:aes-gcm"]
 chacha = ["dep:chacha20poly1305"]
-hkdf = ["dep:hkdf", "dep:sha2"]
+hkdfsha2 = ["dep:hkdf", "dep:sha2"]
 shake = ["dep:sha3", "dep:turboshake"]
 # Include allocating methods like open() and seal()
 alloc = []
 # Enable RNG-less top-level functions
 getrandom = ["dep:getrandom"]
-# Used to enable known-answer tests. Implies alloc and all other features
-kat = ["alloc", "getrandom", "aes", "chacha", "x25519", "nistp", "mlkem", "hkdf", "shake"]
+# Used to enable known-answer tests. Implies all other features
+kat = ["alloc", "getrandom", "aes", "chacha", "x25519", "nistp", "mlkem", "hkdfsha2", "shake"]
 hazmat-streaming-enc = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,34 +13,20 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [features]
-# "p256" enables the use of ECDH-NIST-P256 as a KEM
-# "p384" enables the use of ECDH-NIST-P384 as a KEM
-# "x25519" enables the use of the X25519 as a KEM
-# "aes" enables AES-GCM AEAD algorithms (AES-128-GCM and AES-256-GCM)
-# "chacha" enables ChaCha20-Poly1305 AEAD algorithm
-# "xwing" enables the use of X-Wing hybrid post-quantum KEM
-# "mlkem768p256" enables the use of MLKEM768-P256 hybrid post-quantum KEM
-# "mlkem1024p384" enables the use of MLKEM1024-P384 hybrid post-quantum KEM
-# "mlkem768" enables the use of the pure ML-KEM-768 post-quantum KEM
-# "mlkem1024" enables the use of the pure ML-KEM-1024 post-quantum KEM
-default = ["getrandom", "alloc", "p256", "x25519", "aes", "chacha"]
-x25519 = ["dep:x25519-dalek"]
-p256 = ["dep:p256"]
-p384 = ["dep:p384"]
-p521 = ["dep:p521"]
+default = ["getrandom", "alloc", "x25519", "mlkem", "chacha"]
+x25519 = ["dep:x25519-dalek", "hkdf"]
+nistp = ["dep:p256", "dep:p384", "dep:p521", "hkdf"]
+mlkem = ["dep:ml-kem", "dep:x-wing", "shake"]
 aes = ["dep:aes-gcm"]
 chacha = ["dep:chacha20poly1305"]
-xwing = ["dep:x-wing"]
-mlkem768p256 = ["dep:ml-kem", "dep:p256"]
-mlkem1024p384 = ["dep:ml-kem", "dep:p384"]
-mlkem768 = ["dep:ml-kem"]
-mlkem1024 = ["dep:ml-kem"]
+hkdf = ["dep:hkdf", "dep:sha2"]
+shake = ["dep:sha3", "dep:turboshake"]
 # Include allocating methods like open() and seal()
 alloc = []
 # Enable RNG-less top-level functions
 getrandom = ["dep:getrandom"]
 # Used to enable known-answer tests. Implies alloc and all other features
-kat = ["alloc", "getrandom", "aes", "chacha", "x25519", "p256", "p384", "p521", "xwing", "mlkem768p256", "mlkem1024p384", "mlkem768", "mlkem1024"]
+kat = ["alloc", "getrandom", "aes", "chacha", "x25519", "nistp", "mlkem", "hkdf", "shake"]
 hazmat-streaming-enc = []
 
 [dependencies]
@@ -49,7 +35,7 @@ aes-gcm = { version = "=0.11.0-rc.3", default-features = false, features = ["aes
 chacha20poly1305 = { version = "=0.11.0-rc.3", default-features = false, optional = true }
 getrandom = { version = "0.4", default-features = false, features = ["sys_rng"], optional = true }
 hybrid-array = "0.4.11"
-hkdf = { version = "0.13", default-features = false }
+hkdf = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.10.0", default-features = false }
 ml-kem = { version = "0.3", default-features = false, features = ["zeroize"], optional = true }
 p256 = { version = "=0.14.0-rc.10", default-features = false, features = [
@@ -64,9 +50,9 @@ p521 = { version = "=0.14.0-rc.10", default-features = false, features = [
     "arithmetic",
     "ecdh",
 ], optional = true }
-sha2 = { version = "0.11", default-features = false }
-sha3 = { version = "0.11", default-features = false, features = ["zeroize"] }
-turboshake = { version = "0.7", default-features = false, features = ["zeroize"] }
+sha2 = { version = "0.11", default-features = false, optional = true }
+sha3 = { version = "0.11", default-features = false, features = ["zeroize"], optional = true }
+turboshake = { version = "0.7", default-features = false, features = ["zeroize"], optional = true }
 subtle = { version = "2.6", default-features = false }
 x25519-dalek = { version = "=3.0.0-pre.6", default-features = false, features = [
     "static_secrets",
@@ -90,7 +76,7 @@ required-features = ["getrandom", "x25519", "chacha"]
 
 [[example]]
 name = "agility"
-required-features = ["getrandom", "p256", "p384", "p521", "x25519", "aes", "chacha"]
+required-features = ["getrandom", "nistp", "x25519", "aes", "chacha"]
 
 # Tell docs.rs to build docs with `--all-features` and `--cfg docsrs` (for nightly docs features)
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ required-features = ["getrandom", "x25519", "chacha"]
 
 [[example]]
 name = "agility"
-required-features = ["getrandom", "nistp", "x25519", "aes", "chacha"]
+required-features = ["getrandom", "nistp", "x25519", "aes", "chacha", "mlkem"]
 
 # Tell docs.rs to build docs with `--all-features` and `--cfg docsrs` (for nightly docs features)
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ The feature flags in this crate allow end-users to avoid pulling in dependencies
 
 ### Feature Flags
 
-Default features flags: `getrandom`, `alloc`
+Default features flags: `getrandom`, `alloc`, `chacha`, `x25519`, `mlkem`. Note this combination means that XWing is enabled by default, as well as all (Turbo)SHAKE KDFs.
 
-* `alloc` (default) - Exposes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
+* `alloc` - Exposes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
 * `getrandom` (default) - Enables top-level functions that use `getrandom` for random number generation, rather than taking in an explicit RNG
 * AEADs:
-  * `chacha` (default) — Enables ChaCha20-Poly1305
+  * `chacha` — Enables ChaCha20-Poly1305
   * `aes` — Enables AES-GCM-128/256
 * KEMs:
-  * `x25519` (default) — Enables the X25519 DHKEM (also enables `hkdf`)
-  * `nistp` — Enables the ECDH-NIST P-256, P-384, and P-521 DHKEMs (also enables `hkdf`)
-  * `mlkem` (default) — Enables the ML-KEM-768 and ML-KEM-1024 post-quantum KEMs (also enables `shake`)
+  * `x25519` — Enables the X25519 DHKEM (also enables `hkdfsha2`)
+  * `nistp` — Enables the ECDH-NIST P-256, P-384, and P-521 DHKEMs (also enables `hkdfsha2`)
+  * `mlkem` — Enables the ML-KEM-768 and ML-KEM-1024 post-quantum KEMs (also enables `shake`)
 * KDFs:
   * `hkdfsha2` — Enables HKDF-SHA256/384/512
   * `shake` — Enables SHAKE128/256 and TurboSHAKE128/256
@@ -125,14 +125,19 @@ To run all benchmarks, execute `cargo bench --all-features`. If you set your own
 
 Ciphersuites benchmarked:
 
-* NIST Ciphersuite with 128-bit security: AES-GCM-128, HKDF-SHA256, ECDH-P256
-* Non-NIST Ciphersuite with 128-bit security: ChaCha20-Poly1305, HKDF-SHA256, X25519
+* Classical NIST Ciphersuite with 128-bit security: AES-GCM-128, HKDF-SHA256, ECDH-P256
+* Classical Non-NIST Ciphersuite with 128-bit security: ChaCha20-Poly1305, HKDF-SHA256, X25519
+* Pure-PQ NIST Ciphersuite with 128-bit security: AES-GCM-128, SHAKE128, MLKEM768
+* Pure-PQ NIST Ciphersuite with 256-bit security: AES-GCM-256, SHAKE256, MLKEM1024
+* Hybrid-PQ NIST Ciphersuite with 128-bit security: AES-GCM-128, SHAKE128, MLKEM768-P256
+* Hybrid-PQ NIST Ciphersuite with 256-bit security: AES-GCM-256, SHAKE256, MLKEM1024-P384
+* Hybrid-PQ Non-NIST Ciphersuite with 128-bit security: ChaCha20-Poly1305, TurboSHAKE128, XWing
 
 Functions benchmarked in each ciphersuite:
 
 * `Kem::gen_keypair`
-* `setup_sender` with OpModes of Base, Auth, Psk, and AuthPsk
-* `setup_receiver` with OpModes of Base, Auth, Psk, and AuthPsk
+* `setup_sender` with OpModes of Base, Auth, Psk, and AuthPsk (Auth* modes omitted if unsupported)
+* `setup_receiver` with OpModes of Base, Auth, Psk, and AuthPsk (Auth* modes omitted if unsupported)
 * `AeadCtxS::seal` with plaintext length 64 and AAD length 64
 * `AeadCtxR::open` with ciphertext length 64 and AAD length 64
 

--- a/README.md
+++ b/README.md
@@ -39,24 +39,32 @@ Here are all the primitives listed in the spec. The primitives with checked boxe
 Crate Features
 --------------
 
-Default features flags: `getrandom`, `alloc`, `x25519`, `p256`, `aes`, `chacha`.
+The feature flags in this crate allow end-users to avoid pulling in dependencies they don't want. We thus take an **additive approach** to features: if you want hybrid post-quantum KEMs, you need to pull in the individual features it relies on. All is explained below.
 
-Feature flag list:
+### Feature Flags
 
-* `alloc` - Includes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
+Default features flags: `getrandom`, `alloc`
+
+* `alloc` - Exposes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
 * `getrandom` - Enables top-level functions that use `getrandom` for random number generation, rather than taking in an explicit RNG
-* `aes` - Enables AES-GCM-128 and AES-GCM-256 AEAD algorithms
-* `chacha` - Enables ChaCha20-Poly1305 AEAD algorithm
-* `x25519` - Enables X25519-based KEMs
-* `p256` - Enables NIST P-256-based KEMs
-* `p384` - Enables NIST P-384-based KEMs
-* `p521` - Enables NIST P-521-based KEMs
-* `xwing` - Enables the X-Wing (aka MLKEM768-X25519) hybrid post-quantum KEM
-* `mlkem768p256` - Enables the MLKEM768-P256 hybrid post-quantum KEM
-* `mlkem1024p384` - Enables the MLKEM1024-P384 hybrid post-quantum KEM
-* `mlkem768` - Enables the pure ML-KEM-768 post-quantum KEM
-* `mlkem1024` - Enables the pure ML-KEM-1024 post-quantum KEM
+* AEADs:
+  * `aes` — Enables AES-GCM-128/256
+  * `chacha` — Enables ChaCha20-Poly1305
+* KEMs:
+  * `x25519` — Enables the X25519 DHKEM (also enables `hkdf`)
+  * `nistp` — Enables the ECDH-NIST P-256, P-384, and P-521 DHKEMs (also enables `hkdf`)
+  * `mlkem` — Enables the ML-KEM-768 and ML-KEM-1024 post-quantum KEMs (also enables `shake`)
+* KDFs:
+  * `hkdf` — Enables HKDF-SHA256/384/512
+  * `shake` — Enables SHAKE128/256 and TurboSHAKE128/256
+* `hazmat-streaming-enc` — Exposes the underlying streaming AEAD context used in HPKE. **DO NOT USE** unless you really know what you're doing.
 * `kat` - Used only to enabled known-answer tests, which require `std`. Only use with `cargo test`
+
+### Feature Combinations
+
+We list the additional functionality that certain feature combinations enable:
+* `x25519,mlkem` — Enables the ML-KEM-768+X25519 (aka XWing) hybrid post-quantum KEM
+* `nistp,mlkem` — Enables the ML-KEM + NIST-P hybrid post-quantum KEMs
 
 For info on how to omit or include feature flags, see the [cargo docs on features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features).
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ Agility
 
 A definition: *crypto agility* refers to the ability of a cryptosystem or protocol to vary its underlying primitives. For example, TLS has "crypto agility" in that you can run the protocol with many different ciphersuites.
 
-This crate does not support crypto agility out of the box. This is because the cryptographic primitives are encoded as types satisfying certain constraints, and types need to be determined at compile time (broadly speaking). That said, there is nothing preventing you from implementing agility yourself. There is a [sample implementation](examples/agility.rs) in the examples folder. The sample implementation is messy because agility is messy.
+This crate does not support crypto agility out of the box. This is because the cryptographic primitives are encoded as types satisfying certain constraints, and types need to be determined at compile time (broadly speaking). Purely for the sake of demonstration, there is a [sample implementation](examples/agility.rs) in the examples folder. The sample implementation is messy because agility is messy.
+
+If you want agility, you can use the [`hpke-dispatch`](https://crates.io/crates/hpke-dispatch) crate.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ The feature flags in this crate allow end-users to avoid pulling in dependencies
 
 Default features flags: `getrandom`, `alloc`
 
-* `alloc` - Exposes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
-* `getrandom` - Enables top-level functions that use `getrandom` for random number generation, rather than taking in an explicit RNG
+* `alloc` (default) - Exposes allocating methods like `AeadCtxR::open()` and `AeadCtxS::seal()`
+* `getrandom` (default) - Enables top-level functions that use `getrandom` for random number generation, rather than taking in an explicit RNG
 * AEADs:
+  * `chacha` (default) — Enables ChaCha20-Poly1305
   * `aes` — Enables AES-GCM-128/256
-  * `chacha` — Enables ChaCha20-Poly1305
 * KEMs:
-  * `x25519` — Enables the X25519 DHKEM (also enables `hkdf`)
+  * `x25519` (default) — Enables the X25519 DHKEM (also enables `hkdf`)
   * `nistp` — Enables the ECDH-NIST P-256, P-384, and P-521 DHKEMs (also enables `hkdf`)
-  * `mlkem` — Enables the ML-KEM-768 and ML-KEM-1024 post-quantum KEMs (also enables `shake`)
+  * `mlkem` (default) — Enables the ML-KEM-768 and ML-KEM-1024 post-quantum KEMs (also enables `shake`)
 * KDFs:
-  * `hkdf` — Enables HKDF-SHA256/384/512
+  * `hkdfsha2` — Enables HKDF-SHA256/384/512
   * `shake` — Enables SHAKE128/256 and TurboSHAKE128/256
 * `hazmat-streaming-enc` — Exposes the underlying streaming AEAD context used in HPKE. **DO NOT USE** unless you really know what you're doing.
 * `kat` - Used only to enabled known-answer tests, which require `std`. Only use with `cargo test`
@@ -63,7 +63,7 @@ Default features flags: `getrandom`, `alloc`
 ### Feature Combinations
 
 We list the additional functionality that certain feature combinations enable:
-* `x25519,mlkem` — Enables the ML-KEM-768+X25519 (aka XWing) hybrid post-quantum KEM
+* `x25519,mlkem` (default) — Enables the ML-KEM-768+X25519 (aka XWing) hybrid post-quantum KEM
 * `nistp,mlkem` — Enables the ML-KEM + NIST-P hybrid post-quantum KEMs
 
 For info on how to omit or include feature flags, see the [cargo docs on features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features).

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -183,7 +183,7 @@ pub fn benches() {
     let mut c = Criterion::default().configure_from_args();
 
     // NIST ciphersuite at the 128-bit security level is AES-GCM-128, HKDF-SHA256, and ECDH-P256
-    #[cfg(all(feature = "p256", feature = "aes"))]
+    #[cfg(all(feature = "nistp", feature = "aes"))]
     bench_ciphersuite::<hpke::aead::AesGcm128, hpke::kdf::HkdfSha256, hpke::kem::DhP256HkdfSha256>(
         "Classical-NIST[seclevel=128]",
         &mut c,
@@ -199,7 +199,7 @@ pub fn benches() {
     >("Classical-NonNIST[seclevel=128]", &mut c, true);
 
     // Pure ML-KEM-768 at the 128-bit security level
-    #[cfg(all(feature = "mlkem768", feature = "aes"))]
+    #[cfg(all(feature = "mlkem", feature = "aes"))]
     bench_ciphersuite::<hpke::aead::AesGcm128, hpke::kdf::KdfShake128, hpke::kem::MlKem768>(
         "MLKEM768-NIST[seclevel=128]",
         &mut c,
@@ -207,7 +207,7 @@ pub fn benches() {
     );
 
     // Pure ML-KEM-1024 at the 256-bit security level
-    #[cfg(all(feature = "mlkem1024", feature = "aes"))]
+    #[cfg(all(feature = "mlkem", feature = "aes"))]
     bench_ciphersuite::<hpke::aead::AesGcm256, hpke::kdf::KdfShake256, hpke::kem::MlKem1024>(
         "MLKEM1024-NIST[seclevel=256]",
         &mut c,
@@ -215,7 +215,7 @@ pub fn benches() {
     );
 
     // Hybrid ML-KEM-768 + NIST-P256 at the 128-bit security level
-    #[cfg(all(feature = "mlkem768p256", feature = "aes"))]
+    #[cfg(all(feature = "mlkem", feature = "nistp", feature = "aes"))]
     bench_ciphersuite::<hpke::aead::AesGcm128, hpke::kdf::KdfShake128, hpke::kem::MlKem768P256>(
         "MLKEM768P256-NIST[seclevel=128]",
         &mut c,
@@ -223,7 +223,7 @@ pub fn benches() {
     );
 
     // Hybrid ML-KEM-1024 + NIST-P384 at the 256-bit security level
-    #[cfg(all(feature = "mlkem1024p384", feature = "aes"))]
+    #[cfg(all(feature = "mlkem", feature = "nistp", feature = "aes"))]
     bench_ciphersuite::<hpke::aead::AesGcm256, hpke::kdf::KdfShake256, hpke::kem::MlKem1024P384>(
         "MLKEM1024P384-NIST[seclevel=256]",
         &mut c,
@@ -231,7 +231,7 @@ pub fn benches() {
     );
 
     // X-Wing hybrid PQ KEM with ChaCha20Poly1305 and SHAKE256
-    #[cfg(all(feature = "xwing", feature = "chacha"))]
+    #[cfg(all(feature = "mlkem", feature = "chacha"))]
     bench_ciphersuite::<hpke::aead::ChaCha20Poly1305, hpke::kdf::KdfTurboShake128, hpke::kem::XWing>(
         "XWing-NonNIST[seclevel=128]",
         &mut c,

--- a/examples/agility.rs
+++ b/examples/agility.rs
@@ -2,8 +2,8 @@
 //! Here's the gist of this file: Instead of doing things at the type level, you can use zero-sized
 //! types and runtime validity checks to do all of HPKE. This file is a rough idea of how one would
 //! go about implementing that. There isn't too much repetition. The main part where you have to
-//! get clever is in `agile_setup_*`, where you have to have a match statement with up to 3·3·5 =
-//! 45 branches for all the different AEAD-KEM-KDF combinations. Practically speaking, though,
+//! get clever is in `agile_setup_*`, where you have to have a match statement with up to 3·7·9 =
+//! 189 branches for all the different AEAD-KEM-KDF combinations. Practically speaking, though,
 //! that's not a big number, so writing that out and using a macro for the actual work (e.g.,
 //! `do_setup_sender!`) seems to be the way to go.
 //!
@@ -15,9 +15,13 @@
 use hpke::{
     aead::{Aead, AeadCtxR, AeadCtxS, AeadTag, AesGcm128, AesGcm256, ChaCha20Poly1305},
     inout::InOutBuf,
-    kdf::{HkdfSha256, HkdfSha384, HkdfSha512, Kdf as KdfTrait},
+    kdf::{
+        HkdfSha256, HkdfSha384, HkdfSha512, Kdf as KdfTrait, KdfShake128, KdfShake256,
+        KdfTurboShake128, KdfTurboShake256,
+    },
     kem::{
-        DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512, Kem as KemTrait, X25519HkdfSha256,
+        DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512, Kem as KemTrait, MlKem1024,
+        MlKem1024P384, MlKem768, MlKem768P256, X25519HkdfSha256, XWing,
     },
     setup_receiver, setup_sender, Deserializable, HpkeError, OpModeR, OpModeS, PskBundle,
     Serializable,
@@ -134,6 +138,10 @@ enum KdfAlg {
     HkdfSha256,
     HkdfSha384,
     HkdfSha512,
+    KdfShake128,
+    KdfShake256,
+    KdfTurboShake128,
+    KdfTurboShake256,
 }
 
 impl KdfAlg {
@@ -142,6 +150,10 @@ impl KdfAlg {
             KdfAlg::HkdfSha256 => "HkdfSha256",
             KdfAlg::HkdfSha384 => "HkdfSha384",
             KdfAlg::HkdfSha512 => "HkdfSha512",
+            KdfAlg::KdfShake128 => "KdfShake128",
+            KdfAlg::KdfShake256 => "KdfShake256",
+            KdfAlg::KdfTurboShake128 => "KdfTurboShake128",
+            KdfAlg::KdfTurboShake256 => "KdfTurboShake256",
         }
     }
 
@@ -150,6 +162,10 @@ impl KdfAlg {
             0x01 => KdfAlg::HkdfSha256,
             0x02 => KdfAlg::HkdfSha384,
             0x03 => KdfAlg::HkdfSha512,
+            0x10 => KdfAlg::KdfShake128,
+            0x11 => KdfAlg::KdfShake256,
+            0x12 => KdfAlg::KdfTurboShake128,
+            0x13 => KdfAlg::KdfTurboShake256,
             _ => return Err(AgileHpkeError::UnknownAlgIdent("KdfAlg", id)),
         };
 
@@ -161,14 +177,10 @@ impl KdfAlg {
             KdfAlg::HkdfSha256 => 0x01,
             KdfAlg::HkdfSha384 => 0x02,
             KdfAlg::HkdfSha512 => 0x03,
-        }
-    }
-
-    fn get_digest_len(&self) -> usize {
-        match self {
-            KdfAlg::HkdfSha256 => 32,
-            KdfAlg::HkdfSha384 => 48,
-            KdfAlg::HkdfSha512 => 64,
+            KdfAlg::KdfShake128 => 0x10,
+            KdfAlg::KdfShake256 => 0x11,
+            KdfAlg::KdfTurboShake128 => 0x12,
+            KdfAlg::KdfTurboShake256 => 0x13,
         }
     }
 }
@@ -180,6 +192,11 @@ enum KemAlg {
     DhP256HkdfSha256,
     DhP384HkdfSha384,
     DhP521HkdfSha512,
+    MlKem768,
+    MlKem1024,
+    MlKem768P256,
+    MlKem1024P384,
+    XWing,
 }
 
 impl KemAlg {
@@ -190,6 +207,11 @@ impl KemAlg {
             KemAlg::DhP521HkdfSha512 => "DhP521HkdfSha512",
             KemAlg::X25519HkdfSha256 => "X25519HkdfSha256",
             KemAlg::X448HkdfSha512 => "X448HkdfSha512",
+            KemAlg::MlKem768 => "MlKem768",
+            KemAlg::MlKem1024 => "MlKem1024",
+            KemAlg::MlKem768P256 => "MlKem768P256",
+            KemAlg::MlKem1024P384 => "MlKem1024P384",
+            KemAlg::XWing => "XWing",
         }
     }
 
@@ -200,6 +222,11 @@ impl KemAlg {
             0x12 => KemAlg::DhP521HkdfSha512,
             0x20 => KemAlg::X25519HkdfSha256,
             0x21 => KemAlg::X448HkdfSha512,
+            0x41 => KemAlg::MlKem768,
+            0x42 => KemAlg::MlKem1024,
+            0x50 => KemAlg::MlKem768P256,
+            0x51 => KemAlg::MlKem1024P384,
+            0x647a => KemAlg::XWing,
             _ => return Err(AgileHpkeError::UnknownAlgIdent("KemAlg", id)),
         };
 
@@ -213,16 +240,28 @@ impl KemAlg {
             KemAlg::DhP521HkdfSha512 => 0x12,
             KemAlg::X25519HkdfSha256 => 0x20,
             KemAlg::X448HkdfSha512 => 0x21,
+            KemAlg::MlKem768 => 0x41,
+            KemAlg::MlKem1024 => 0x42,
+            KemAlg::MlKem768P256 => 0x50,
+            KemAlg::MlKem1024P384 => 0x51,
+            KemAlg::XWing => 0x647a,
         }
     }
 
-    fn kdf_alg(&self) -> KdfAlg {
+    /// Returns whether this KEM supports authenticated encapsulation (Auth/AuthPsk modes).
+    /// Post-quantum KEMs do not support auth modes.
+    fn supports_auth(&self) -> bool {
         match self {
-            KemAlg::X25519HkdfSha256 => KdfAlg::HkdfSha256,
-            KemAlg::X448HkdfSha512 => KdfAlg::HkdfSha512,
-            KemAlg::DhP256HkdfSha256 => KdfAlg::HkdfSha256,
-            KemAlg::DhP384HkdfSha384 => KdfAlg::HkdfSha384,
-            KemAlg::DhP521HkdfSha512 => KdfAlg::HkdfSha512,
+            KemAlg::X25519HkdfSha256
+            | KemAlg::X448HkdfSha512
+            | KemAlg::DhP256HkdfSha256
+            | KemAlg::DhP384HkdfSha384
+            | KemAlg::DhP521HkdfSha512 => true,
+            KemAlg::MlKem768
+            | KemAlg::MlKem1024
+            | KemAlg::MlKem768P256
+            | KemAlg::MlKem1024P384
+            | KemAlg::XWing => false,
         }
     }
 }
@@ -309,6 +348,11 @@ fn agile_gen_keypair(kem_alg: KemAlg) -> AgileKeypair {
         KemAlg::DhP256HkdfSha256 => do_gen_keypair!(DhP256HkdfSha256, kem_alg),
         KemAlg::DhP384HkdfSha384 => do_gen_keypair!(DhP384HkdfSha384, kem_alg),
         KemAlg::DhP521HkdfSha512 => do_gen_keypair!(DhP521HkdfSha512, kem_alg),
+        KemAlg::MlKem768 => do_gen_keypair!(MlKem768, kem_alg),
+        KemAlg::MlKem1024 => do_gen_keypair!(MlKem1024, kem_alg),
+        KemAlg::MlKem768P256 => do_gen_keypair!(MlKem768P256, kem_alg),
+        KemAlg::MlKem1024P384 => do_gen_keypair!(MlKem1024P384, kem_alg),
+        KemAlg::XWing => do_gen_keypair!(XWing, kem_alg),
         _ => unimplemented!(),
     }
 }
@@ -568,8 +612,10 @@ fn agile_setup_sender(
     hpke_dispatch!(
         res, to_match,
         (ChaCha20Poly1305, AesGcm128, AesGcm256),
-        (HkdfSha256, HkdfSha384, HkdfSha512),
-        (X25519HkdfSha256, DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512),
+        (HkdfSha256, HkdfSha384, HkdfSha512,
+         KdfShake128, KdfShake256, KdfTurboShake128, KdfTurboShake256),
+        (X25519HkdfSha256, DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512,
+         MlKem768, MlKem1024, MlKem768P256, MlKem1024P384, XWing),
         do_setup_sender,
             mode,
             pk_recip,
@@ -645,8 +691,10 @@ fn agile_setup_receiver(
     hpke_dispatch!(
         res, to_match,
         (ChaCha20Poly1305, AesGcm128, AesGcm256),
-        (HkdfSha256, HkdfSha384, HkdfSha512),
-        (X25519HkdfSha256, DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512),
+        (HkdfSha256, HkdfSha384, HkdfSha512,
+         KdfShake128, KdfShake256, KdfTurboShake128, KdfTurboShake256),
+        (X25519HkdfSha256, DhP256HkdfSha256, DhP384HkdfSha384, DhP521HkdfSha512,
+         MlKem768, MlKem1024, MlKem768P256, MlKem1024P384, XWing),
         do_setup_receiver,
             mode,
             recip_keypair,
@@ -672,8 +720,21 @@ fn main() {
         KemAlg::DhP256HkdfSha256,
         KemAlg::DhP384HkdfSha384,
         KemAlg::DhP521HkdfSha512,
+        KemAlg::MlKem768,
+        KemAlg::MlKem1024,
+        KemAlg::MlKem768P256,
+        KemAlg::MlKem1024P384,
+        KemAlg::XWing,
     ];
-    let supported_kdf_algs = &[KdfAlg::HkdfSha256, KdfAlg::HkdfSha384, KdfAlg::HkdfSha512];
+    let supported_kdf_algs = &[
+        KdfAlg::HkdfSha256,
+        KdfAlg::HkdfSha384,
+        KdfAlg::HkdfSha512,
+        KdfAlg::KdfShake128,
+        KdfAlg::KdfShake256,
+        KdfAlg::KdfTurboShake128,
+        KdfAlg::KdfTurboShake256,
+    ];
 
     // For every combination of supported algorithms, test an encryption-decryption round trip
     for &aead_alg in supported_aead_algs {
@@ -683,24 +744,41 @@ fn main() {
 
                 // Make a random sender keypair and PSK bundle
                 let sender_keypair = agile_gen_keypair(kem_alg);
-                let mut psk_bytes = vec![0u8; kdf_alg.get_digest_len()];
+                let mut psk_bytes = [0u8; 32];
                 let psk_id = b"preshared key attempt #5, take 2. action";
                 let psk_bundle = {
                     rand::fill(&mut psk_bytes);
                     AgilePskBundle(PskBundle::new(&psk_bytes, psk_id).unwrap())
                 };
 
-                // Make two agreeing OpModes (AuthPsk is the most complicated, so we're just using
-                // that).
-                let op_mode_s_ty = AgileOpModeSTy::AuthPsk(sender_keypair.clone(), psk_bundle);
-                let op_mode_s = AgileOpModeS {
-                    kem_alg,
-                    op_mode_ty: op_mode_s_ty,
-                };
-                let op_mode_r_ty = AgileOpModeRTy::AuthPsk(sender_keypair.1, psk_bundle);
-                let op_mode_r = AgileOpModeR {
-                    kem_alg,
-                    op_mode_ty: op_mode_r_ty,
+                // Build OpModes. PQ KEMs don't support Auth/AuthPsk, so use Psk for them
+                // and AuthPsk for classical KEMs.
+                let (op_mode_s, op_mode_r) = if kem_alg.supports_auth() {
+                    let op_mode_s_ty = AgileOpModeSTy::AuthPsk(sender_keypair.clone(), psk_bundle);
+                    let op_mode_r_ty = AgileOpModeRTy::AuthPsk(sender_keypair.1, psk_bundle);
+                    (
+                        AgileOpModeS {
+                            kem_alg,
+                            op_mode_ty: op_mode_s_ty,
+                        },
+                        AgileOpModeR {
+                            kem_alg,
+                            op_mode_ty: op_mode_r_ty,
+                        },
+                    )
+                } else {
+                    let op_mode_s_ty = AgileOpModeSTy::Psk(psk_bundle);
+                    let op_mode_r_ty = AgileOpModeRTy::Psk(psk_bundle);
+                    (
+                        AgileOpModeS {
+                            kem_alg,
+                            op_mode_ty: op_mode_s_ty,
+                        },
+                        AgileOpModeR {
+                            kem_alg,
+                            op_mode_ty: op_mode_r_ty,
+                        },
+                    )
                 };
 
                 // Set up the sender's encryption context
@@ -715,7 +793,7 @@ fn main() {
                 )
                 .unwrap();
 
-                // Set up the receivers's encryption context
+                // Set up the receiver's encryption context
                 let mut aead_ctx2 = agile_setup_receiver(
                     aead_alg,
                     kdf_alg,

--- a/examples/client_server.rs
+++ b/examples/client_server.rs
@@ -18,17 +18,17 @@
 use hpke::{
     aead::{AeadTag, ChaCha20Poly1305},
     inout::InOutBuf,
-    kdf::HkdfSha384,
-    kem::X25519HkdfSha256,
+    kdf::KdfTurboShake128,
+    kem::XWing,
     Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable,
 };
 
 const INFO_STR: &[u8] = b"example session";
 
 // These are the only algorithms we're gonna use for this example
-type Kem = X25519HkdfSha256;
+type Kem = XWing;
 type Aead = ChaCha20Poly1305;
-type Kdf = HkdfSha384;
+type Kdf = KdfTurboShake128;
 
 // Initializes the server with a fresh keypair
 fn server_init() -> (<Kem as KemTrait>::PrivateKey, <Kem as KemTrait>::PublicKey) {

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -502,7 +502,7 @@ mod test {
     #[cfg(feature = "chacha")]
     use super::ChaCha20Poly1305;
 
-    #[cfg(feature = "hkdf")]
+    #[cfg(feature = "hkdfsha2")]
     use crate::kdf::HkdfSha256;
     use crate::{test_util::gen_ctx_simple_pair, Deserializable, HpkeError, Serializable};
 

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -502,9 +502,9 @@ mod test {
     #[cfg(feature = "chacha")]
     use super::ChaCha20Poly1305;
 
-    use crate::{
-        kdf::HkdfSha256, test_util::gen_ctx_simple_pair, Deserializable, HpkeError, Serializable,
-    };
+    #[cfg(feature = "hkdf")]
+    use crate::kdf::HkdfSha256;
+    use crate::{test_util::gen_ctx_simple_pair, Deserializable, HpkeError, Serializable};
 
     use hybrid_array::typenum::Unsigned;
 
@@ -753,9 +753,11 @@ mod test {
         );
     }
 
-    #[cfg(all(feature = "p256", feature = "alloc", feature = "chacha"))]
-    mod p256_tests {
+    #[cfg(all(feature = "nistp", feature = "alloc", feature = "chacha"))]
+    mod nistp_tests {
         use super::*;
+
+        // P-256
 
         test_export_idempotence!(test_export_idempotence_p256, crate::kem::DhP256HkdfSha256);
         test_exportonly_panics!(
@@ -782,11 +784,8 @@ mod test {
             ChaCha20Poly1305,
             crate::kem::DhP256HkdfSha256
         );
-    }
 
-    #[cfg(all(feature = "p384", feature = "alloc", feature = "chacha"))]
-    mod p384_tests {
-        use super::*;
+        // P-384
 
         test_export_idempotence!(test_export_idempotence_p384, crate::kem::DhP384HkdfSha384);
         test_exportonly_panics!(

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -502,8 +502,6 @@ mod test {
     #[cfg(feature = "chacha")]
     use super::ChaCha20Poly1305;
 
-    #[cfg(feature = "hkdfsha2")]
-    use crate::kdf::HkdfSha256;
     use crate::{test_util::gen_ctx_simple_pair, Deserializable, HpkeError, Serializable};
 
     use hybrid_array::typenum::Unsigned;
@@ -535,11 +533,11 @@ mod test {
     /// over ciphers.
     #[cfg(feature = "alloc")]
     macro_rules! test_export_idempotence {
-        ($test_name:ident, $kem_ty:ty) => {
+        ($test_name:ident, $kdf_ty:ty, $kem_ty:ty) => {
             #[test]
             fn $test_name() {
                 type Kem = $kem_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 // Again, this test is cipher-agnostic
                 type A = ChaCha20Poly1305;
 
@@ -572,12 +570,12 @@ mod test {
     /// panic
     #[cfg(feature = "alloc")]
     macro_rules! test_exportonly_panics {
-        ($test_name1:ident, $test_name2:ident, $kem_ty:ty) => {
+        ($test_name1:ident, $test_name2:ident, $kdf_ty:ty, $kem_ty:ty) => {
             #[should_panic]
             #[test]
             fn $test_name1() {
                 type Kem = $kem_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 type A = ExportOnlyAead;
 
                 // Set up a context and try encrypting
@@ -590,7 +588,7 @@ mod test {
             #[test]
             fn $test_name2() {
                 type Kem = $kem_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 type A = ExportOnlyAead;
 
                 // Set up a context and try decrypting an invalid ciphertext
@@ -606,11 +604,11 @@ mod test {
     /// make the test generic over ciphers.
     #[cfg(feature = "alloc")]
     macro_rules! test_overflow {
-        ($test_name:ident, $kem_ty:ty) => {
+        ($test_name:ident, $kdf_ty:ty, $kem_ty:ty) => {
             #[test]
             fn $test_name() {
                 type Kem = $kem_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 // Again, this test is cipher-agnostic
                 type A = ChaCha20Poly1305;
 
@@ -676,11 +674,11 @@ mod test {
     /// Tests that `open()` can decrypt things properly encrypted with `seal()`
     #[cfg(feature = "alloc")]
     macro_rules! test_ctx_correctness {
-        ($test_name:ident, $aead_ty:ty, $kem_ty:ty) => {
+        ($test_name:ident, $aead_ty:ty, $kdf_ty:ty, $kem_ty:ty) => {
             #[test]
             fn $test_name() {
                 type A = $aead_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 type Kem = $kem_ty;
 
                 let (mut sender_ctx, mut receiver_ctx) = gen_ctx_simple_pair::<A, Kdf, Kem>();
@@ -725,30 +723,43 @@ mod test {
     #[cfg(all(feature = "x25519", feature = "alloc", feature = "chacha"))]
     mod x25519_tests {
         use super::*;
+        use crate::kdf::HkdfSha256;
 
-        test_export_idempotence!(test_export_idempotence_x25519, crate::kem::X25519HkdfSha256);
+        test_export_idempotence!(
+            test_export_idempotence_x25519,
+            HkdfSha256,
+            crate::kem::X25519HkdfSha256
+        );
         test_exportonly_panics!(
             test_exportonly_panics_x25519_seal,
             test_exportonly_panics_x25519_open,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
-        test_overflow!(test_overflow_x25519, crate::kem::X25519HkdfSha256);
+        test_overflow!(
+            test_overflow_x25519,
+            HkdfSha256,
+            crate::kem::X25519HkdfSha256
+        );
 
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes128_x25519,
             AesGcm128,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes256_x25519,
             AesGcm256,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
         test_ctx_correctness!(
             test_ctx_correctness_chacha_x25519,
             ChaCha20Poly1305,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
     }
@@ -756,61 +767,245 @@ mod test {
     #[cfg(all(feature = "nistp", feature = "alloc", feature = "chacha"))]
     mod nistp_tests {
         use super::*;
+        use crate::kdf::HkdfSha256;
 
         // P-256
 
-        test_export_idempotence!(test_export_idempotence_p256, crate::kem::DhP256HkdfSha256);
+        test_export_idempotence!(
+            test_export_idempotence_p256,
+            HkdfSha256,
+            crate::kem::DhP256HkdfSha256
+        );
         test_exportonly_panics!(
             test_exportonly_panics_p256_seal,
             test_exportonly_panics_p256_open,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
-        test_overflow!(test_overflow_p256, crate::kem::DhP256HkdfSha256);
+        test_overflow!(test_overflow_p256, HkdfSha256, crate::kem::DhP256HkdfSha256);
 
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes128_p256,
             AesGcm128,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes256_p256,
             AesGcm256,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
         test_ctx_correctness!(
             test_ctx_correctness_chacha_p256,
             ChaCha20Poly1305,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
 
         // P-384
 
-        test_export_idempotence!(test_export_idempotence_p384, crate::kem::DhP384HkdfSha384);
+        test_export_idempotence!(
+            test_export_idempotence_p384,
+            HkdfSha256,
+            crate::kem::DhP384HkdfSha384
+        );
         test_exportonly_panics!(
             test_exportonly_panics_p384_seal,
             test_exportonly_panics_p384_open,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
         );
-        test_overflow!(test_overflow_p384, crate::kem::DhP384HkdfSha384);
+        test_overflow!(test_overflow_p384, HkdfSha256, crate::kem::DhP384HkdfSha384);
 
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes128_p384,
             AesGcm128,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
         );
         #[cfg(feature = "aes")]
         test_ctx_correctness!(
             test_ctx_correctness_aes256_p384,
             AesGcm256,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
         );
         test_ctx_correctness!(
             test_ctx_correctness_chacha_p384,
             ChaCha20Poly1305,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
+        );
+
+        // P-521
+
+        test_export_idempotence!(
+            test_export_idempotence_p521,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_p521_seal,
+            test_exportonly_panics_p521_open,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+        test_overflow!(test_overflow_p521, HkdfSha256, crate::kem::DhP521HkdfSha512);
+
+        #[cfg(feature = "aes")]
+        test_ctx_correctness!(
+            test_ctx_correctness_aes128_p521,
+            AesGcm128,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+        #[cfg(feature = "aes")]
+        test_ctx_correctness!(
+            test_ctx_correctness_aes256_p521,
+            AesGcm256,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_p521,
+            ChaCha20Poly1305,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "alloc", feature = "chacha"))]
+    mod mlkem_tests {
+        use super::*;
+        use crate::kdf::KdfShake128;
+
+        test_export_idempotence!(
+            test_export_idempotence_mlkem768,
+            KdfShake128,
+            crate::kem::MlKem768
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_mlkem768_seal,
+            test_exportonly_panics_mlkem768_open,
+            KdfShake128,
+            crate::kem::MlKem768
+        );
+        test_overflow!(test_overflow_mlkem768, KdfShake128, crate::kem::MlKem768);
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_mlkem768,
+            ChaCha20Poly1305,
+            KdfShake128,
+            crate::kem::MlKem768
+        );
+
+        test_export_idempotence!(
+            test_export_idempotence_mlkem1024,
+            KdfShake128,
+            crate::kem::MlKem1024
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_mlkem1024_seal,
+            test_exportonly_panics_mlkem1024_open,
+            KdfShake128,
+            crate::kem::MlKem1024
+        );
+        test_overflow!(test_overflow_mlkem1024, KdfShake128, crate::kem::MlKem1024);
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_mlkem1024,
+            ChaCha20Poly1305,
+            KdfShake128,
+            crate::kem::MlKem1024
+        );
+    }
+
+    #[cfg(all(
+        feature = "mlkem",
+        feature = "nistp",
+        feature = "alloc",
+        feature = "chacha"
+    ))]
+    mod mlkem_nistp_tests {
+        use super::*;
+        use crate::kdf::{KdfShake128, KdfShake256};
+
+        test_export_idempotence!(
+            test_export_idempotence_mlkem768p256,
+            KdfShake128,
+            crate::kem::MlKem768P256
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_mlkem768p256_seal,
+            test_exportonly_panics_mlkem768p256_open,
+            KdfShake128,
+            crate::kem::MlKem768P256
+        );
+        test_overflow!(
+            test_overflow_mlkem768p256,
+            KdfShake128,
+            crate::kem::MlKem768P256
+        );
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_mlkem768p256,
+            ChaCha20Poly1305,
+            KdfShake128,
+            crate::kem::MlKem768P256
+        );
+
+        test_export_idempotence!(
+            test_export_idempotence_mlkem1024p384,
+            KdfShake128,
+            crate::kem::MlKem1024P384
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_mlkem1024p384_seal,
+            test_exportonly_panics_mlkem1024p384_open,
+            KdfShake256,
+            crate::kem::MlKem1024P384
+        );
+        test_overflow!(
+            test_overflow_mlkem1024p384,
+            KdfShake256,
+            crate::kem::MlKem1024P384
+        );
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_mlkem1024p384,
+            ChaCha20Poly1305,
+            KdfShake256,
+            crate::kem::MlKem1024P384
+        );
+    }
+
+    #[cfg(all(
+        feature = "mlkem",
+        feature = "x25519",
+        feature = "alloc",
+        feature = "chacha"
+    ))]
+    mod xwing_tests {
+        use super::*;
+        use crate::kdf::KdfTurboShake128;
+
+        test_export_idempotence!(
+            test_export_idempotence_xwing,
+            KdfTurboShake128,
+            crate::kem::XWing
+        );
+        test_exportonly_panics!(
+            test_exportonly_panics_xwing_seal,
+            test_exportonly_panics_xwing_open,
+            KdfTurboShake128,
+            crate::kem::XWing
+        );
+        test_overflow!(test_overflow_xwing, KdfTurboShake128, crate::kem::XWing);
+        test_ctx_correctness!(
+            test_ctx_correctness_chacha_xwing,
+            ChaCha20Poly1305,
+            KdfTurboShake128,
+            crate::kem::XWing
         );
     }
 

--- a/src/dhkex.rs
+++ b/src/dhkex.rs
@@ -44,7 +44,7 @@ pub trait DhKeyExchange {
     ) -> (Self::PrivateKey, Self::PublicKey);
 }
 
-#[cfg(any(feature = "p256", feature = "p384", feature = "p521"))]
+#[cfg(feature = "nistp")]
 pub(crate) mod ecdh_nistp;
 
 #[cfg(feature = "x25519")]

--- a/src/dhkex/ecdh_nistp.rs
+++ b/src/dhkex/ecdh_nistp.rs
@@ -239,7 +239,6 @@ macro_rules! nistp_dhkex {
 
 use hybrid_array::typenum;
 
-#[cfg(feature = "p256")]
 nistp_dhkex!(
     "P-256",
     DhP256,
@@ -250,7 +249,6 @@ nistp_dhkex!(
     0xFF          // RFC 9180 §7.1.3: The `bitmask` in DeriveKeyPair to be 0xFF for P-256
 );
 
-#[cfg(feature = "p384")]
 nistp_dhkex!(
     "P-384",
     DhP384,
@@ -261,7 +259,6 @@ nistp_dhkex!(
     0xFF          // RFC 9180 §7.1.3: The `bitmask` in DeriveKeyPair to be 0xFF for P-384
 );
 
-#[cfg(feature = "p521")]
 nistp_dhkex!(
     "P-521",
     DhP521,
@@ -278,11 +275,8 @@ mod tests {
         dhkex::DhKeyExchange, test_util::dhkex_gen_keypair_with_rng, Deserializable, Serializable,
     };
 
-    #[cfg(feature = "p256")]
     use super::p256::DhP256;
-    #[cfg(feature = "p384")]
     use super::p384::DhP384;
-    #[cfg(feature = "p521")]
     use super::p521::DhP521;
 
     use hex_literal::hex;
@@ -292,14 +286,12 @@ mod tests {
     // https://tools.ietf.org/html/rfc5903
     //
 
-    #[cfg(feature = "p256")]
     const P256_PRIVKEYS: &[&[u8]] = &[
         &hex!("C88F01F5 10D9AC3F 70A292DA A2316DE5 44E9AAB8 AFE84049 C62A9C57 862D1433"),
         &hex!("C6EF9C5D 78AE012A 011164AC B397CE20 88685D8F 06BF9BE0 B283AB46 476BEE53"),
     ];
 
     // The public keys corresponding to the above private keys, in order
-    #[cfg(feature = "p256")]
     const P256_PUBKEYS: &[&[u8]] = &[
         &hex!(
             "04"                                                                      // Uncompressed
@@ -314,11 +306,9 @@ mod tests {
     ];
 
     // The result of DH(privkey0, pubkey1) or equivalently, DH(privkey1, pubkey0)
-    #[cfg(feature = "p256")]
     const P256_DH_RES_XCOORD: &[u8] =
         &hex!("D6840F6B 42F6EDAF D13116E0 E1256520 2FEF8E9E CE7DCE03 812464D0 4B9442DE");
 
-    #[cfg(feature = "p384")]
     const P384_PRIVKEYS: &[&[u8]] = &[
         &hex!(
             "099F3C70 34D4A2C6 99884D73 A375A67F 7624EF7C 6B3C0F16 0647B674 14DCE655 E35B5380"
@@ -331,7 +321,6 @@ mod tests {
     ];
 
     // The public keys corresponding to the above private keys, in order
-    #[cfg(feature = "p384")]
     const P384_PUBKEYS: &[&[u8]] = &[
         &hex!(
             "04"                                                             // Uncompressed
@@ -350,13 +339,11 @@ mod tests {
     ];
 
     // The result of DH(privkey0, pubkey1) or equivalently, DH(privkey1, pubkey0)
-    #[cfg(feature = "p384")]
     const P384_DH_RES_XCOORD: &[u8] = &hex!(
         "11187331 C279962D 93D60424 3FD592CB 9D0A926F 422E4718 7521287E 7156C5C4 D6031355"
         "69B9E9D0 9CF5D4A2 70F59746"
     );
 
-    #[cfg(feature = "p521")]
     const P521_PRIVKEYS: &[&[u8]] = &[
         &hex!(
             "0037ADE9 319A89F4 DABDB3EF 411AACCC A5123C61 ACAB57B5 393DCE47 608172A0"
@@ -371,7 +358,6 @@ mod tests {
     ];
 
     // The public keys corresponding to the above private keys, in order
-    #[cfg(feature = "p521")]
     const P521_PUBKEYS: &[&[u8]] = &[
         &hex!(
             "04"                                                                      // Uncompressed
@@ -394,7 +380,6 @@ mod tests {
     ];
 
     // The result of DH(privkey0, pubkey1) or equivalently, DH(privkey1, pubkey0)
-    #[cfg(feature = "p521")]
     const P521_DH_RES_XCOORD: &[u8] = &hex!(
         "01144C7D 79AE6956 BC8EDB8E 7C787C45 21CB086F A64407F9 7894E5E6 B2D79B04"
         "D1427E73 CA4BAA24 0A347868 59810C06 B3C715A3 A8CC3151 F2BEE417 996D19F3"
@@ -477,73 +462,61 @@ mod tests {
         assert!(new_pk == pk, "public key doesn't serialize correctly");
     }
 
-    #[cfg(feature = "p256")]
     #[test]
     fn test_vector_ecdh_p256() {
         test_vector_ecdh::<DhP256>(P256_PRIVKEYS[0], P256_PUBKEYS[1], P256_DH_RES_XCOORD);
     }
 
-    #[cfg(feature = "p384")]
     #[test]
     fn test_vector_ecdh_p384() {
         test_vector_ecdh::<DhP384>(P384_PRIVKEYS[0], P384_PUBKEYS[1], P384_DH_RES_XCOORD);
     }
 
-    #[cfg(feature = "p521")]
     #[test]
     fn test_vector_ecdh_p521() {
         test_vector_ecdh::<DhP521>(P521_PRIVKEYS[0], P521_PUBKEYS[1], P521_DH_RES_XCOORD);
     }
 
-    #[cfg(feature = "p256")]
     #[test]
     fn test_vector_corresponding_pubkey_p256() {
         test_vector_corresponding_pubkey::<DhP256>(P256_PRIVKEYS, P256_PUBKEYS);
     }
 
-    #[cfg(feature = "p384")]
     #[test]
     fn test_vector_corresponding_pubkey_p384() {
         test_vector_corresponding_pubkey::<DhP384>(P384_PRIVKEYS, P384_PUBKEYS);
     }
 
-    #[cfg(feature = "p521")]
     #[test]
     fn test_vector_corresponding_pubkey_p521() {
         test_vector_corresponding_pubkey::<DhP521>(P521_PRIVKEYS, P521_PUBKEYS);
     }
 
-    #[cfg(feature = "p256")]
     #[test]
     fn test_pubkey_serialize_correctness_p256() {
         test_pubkey_serialize_correctness::<DhP256>();
     }
 
-    #[cfg(feature = "p384")]
     #[test]
     fn test_pubkey_serialize_correctness_p384() {
         test_pubkey_serialize_correctness::<DhP384>();
     }
 
-    #[cfg(feature = "p521")]
     #[test]
     fn test_pubkey_serialize_correctness_p521() {
         test_pubkey_serialize_correctness::<DhP521>();
     }
 
-    #[cfg(feature = "p256")]
     #[test]
     fn test_dh_serialize_correctness_p256() {
         test_dh_serialize_correctness::<DhP256>();
     }
 
-    #[cfg(feature = "p384")]
     #[test]
     fn test_dh_serialize_correctness_p384() {
         test_dh_serialize_correctness::<DhP384>();
     }
 
-    #[cfg(feature = "p521")]
     #[test]
     fn test_dh_serialize_correctness_p521() {
         test_dh_serialize_correctness::<DhP521>();

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -138,7 +138,6 @@ impl KdfTrait for HkdfSha256 {
         out: &mut [u8],
     ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha256>(ikm, suite_id, info, out)
-            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {
@@ -193,7 +192,6 @@ impl KdfTrait for HkdfSha384 {
         out: &mut [u8],
     ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha384>(ikm, suite_id, info, out)
-            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {
@@ -248,7 +246,6 @@ impl KdfTrait for HkdfSha512 {
         out: &mut [u8],
     ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha512>(ikm, suite_id, info, out)
-            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -8,25 +8,22 @@ use crate::{
     HpkeError,
 };
 
-#[cfg(feature = "hkdf")]
-use hybrid_array::typenum::U48;
 use hybrid_array::{
     typenum::{U32, U64},
     Array, ArraySize,
 };
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 use sha2::{Sha256, Sha384, Sha512};
 
 #[cfg(feature = "shake")]
 pub(crate) mod one_stage_kdf;
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 mod two_stage_kdf;
 
-#[cfg(any(feature = "hkdf", feature = "shake"))]
 pub(crate) const VERSION_LABEL: &[u8] = b"HPKE-v1";
 
 // This is the maximum value of Nh. It is achieved by HKDF-SHA512 in RFC 9180 §7.2.
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 pub(crate) const MAX_DIGEST_SIZE: usize = 64;
 
 // Pretty much all the KDF functionality is covered by the hkdf crate
@@ -111,11 +108,11 @@ pub(crate) type DigestArray<Kdf> = Array<u8, <Kdf as KdfTrait>::Nh>;
 // Implement KdfTrait for all our KDFs. Call the one- or two-stage implementation for each of them
 //
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 /// The implementation of HKDF-SHA256
 pub struct HkdfSha256 {}
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 impl KdfTrait for HkdfSha256 {
     // RFC 9180 §7.2: HKDF-SHA256
     const KDF_ID: u16 = 0x0001;
@@ -166,15 +163,15 @@ impl KdfTrait for HkdfSha256 {
     }
 }
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 /// The implementation of HKDF-SHA384
 pub struct HkdfSha384 {}
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 impl KdfTrait for HkdfSha384 {
     // RFC 9180 §7.2: HKDF-SHA384
     const KDF_ID: u16 = 0x0002;
-    type Nh = U48;
+    type Nh = hybrid_array::typenum::U48;
 
     fn combine_secrets<A, Kem, O>(
         mode: &O,
@@ -221,11 +218,11 @@ impl KdfTrait for HkdfSha384 {
     }
 }
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 /// The implementation of HKDF-SHA512
 pub struct HkdfSha512 {}
 
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 impl KdfTrait for HkdfSha512 {
     // RFC 9180 §7.2: HKDF-SHA512
     const KDF_ID: u16 = 0x0003;

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -8,18 +8,25 @@ use crate::{
     HpkeError,
 };
 
+#[cfg(feature = "hkdf")]
+use hybrid_array::typenum::U48;
 use hybrid_array::{
-    typenum::{U32, U48, U64},
+    typenum::{U32, U64},
     Array, ArraySize,
 };
+#[cfg(feature = "hkdf")]
 use sha2::{Sha256, Sha384, Sha512};
 
+#[cfg(feature = "shake")]
 pub(crate) mod one_stage_kdf;
+#[cfg(feature = "hkdf")]
 mod two_stage_kdf;
 
+#[cfg(any(feature = "hkdf", feature = "shake"))]
 pub(crate) const VERSION_LABEL: &[u8] = b"HPKE-v1";
 
 // This is the maximum value of Nh. It is achieved by HKDF-SHA512 in RFC 9180 §7.2.
+#[cfg(feature = "hkdf")]
 pub(crate) const MAX_DIGEST_SIZE: usize = 64;
 
 // Pretty much all the KDF functionality is covered by the hkdf crate
@@ -52,14 +59,14 @@ pub trait Kdf: Sized {
 
     /// Extracts randomness from `ikm`, binds it to the given suite ID and info string, and expands
     /// the result to fill the output buffer.  If `out.len()` is more than 255x the digest size (in
-    /// bytes) of the underlying hash function, returns an `Err(hkdf::InvalidLength)`.
+    /// bytes) of the underlying hash function, returns an `Err(HpkeError::KdfOutputTooLong)`.
     #[doc(hidden)]
     fn extract_and_expand(
         ikm: &[u8],
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength>;
+    ) -> Result<(), HpkeError>;
 
     /// Derives bytes for a use as a P256/P384/P521 ephemeral secret. Counter is because it may
     /// require multiple attempts to find a valid scalar. The keying material SHOULD have as many
@@ -88,7 +95,9 @@ pub trait Kdf: Sized {
     ) -> Result<(), HpkeError>;
 }
 
+#[cfg(feature = "shake")]
 use sha3::{Shake128, Shake256};
+#[cfg(feature = "shake")]
 use turboshake::{TurboShake128, TurboShake256};
 // We use Kdf as a type parameter, so this is to avoid ambiguity.
 use Kdf as KdfTrait;
@@ -102,9 +111,11 @@ pub(crate) type DigestArray<Kdf> = Array<u8, <Kdf as KdfTrait>::Nh>;
 // Implement KdfTrait for all our KDFs. Call the one- or two-stage implementation for each of them
 //
 
+#[cfg(feature = "hkdf")]
 /// The implementation of HKDF-SHA256
 pub struct HkdfSha256 {}
 
+#[cfg(feature = "hkdf")]
 impl KdfTrait for HkdfSha256 {
     // RFC 9180 §7.2: HKDF-SHA256
     const KDF_ID: u16 = 0x0001;
@@ -128,8 +139,9 @@ impl KdfTrait for HkdfSha256 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha256>(ikm, suite_id, info, out)
+            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {
@@ -154,9 +166,11 @@ impl KdfTrait for HkdfSha256 {
     }
 }
 
+#[cfg(feature = "hkdf")]
 /// The implementation of HKDF-SHA384
 pub struct HkdfSha384 {}
 
+#[cfg(feature = "hkdf")]
 impl KdfTrait for HkdfSha384 {
     // RFC 9180 §7.2: HKDF-SHA384
     const KDF_ID: u16 = 0x0002;
@@ -180,8 +194,9 @@ impl KdfTrait for HkdfSha384 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha384>(ikm, suite_id, info, out)
+            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {
@@ -206,9 +221,11 @@ impl KdfTrait for HkdfSha384 {
     }
 }
 
+#[cfg(feature = "hkdf")]
 /// The implementation of HKDF-SHA512
 pub struct HkdfSha512 {}
 
+#[cfg(feature = "hkdf")]
 impl KdfTrait for HkdfSha512 {
     // RFC 9180 §7.2: HKDF-SHA512
     const KDF_ID: u16 = 0x0003;
@@ -232,8 +249,9 @@ impl KdfTrait for HkdfSha512 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         two_stage_kdf::extract_and_expand::<Sha512>(ikm, suite_id, info, out)
+            .map_err(|_| HpkeError::KdfOutputTooLong)
     }
 
     fn derive_x25519_sk_eph_bytes(suite_id: &KemSuiteId, ikm: &[u8]) -> [u8; 32] {
@@ -258,9 +276,11 @@ impl KdfTrait for HkdfSha512 {
     }
 }
 
+#[cfg(feature = "shake")]
 /// The implementation of SHAKE128 KDF
 pub struct KdfShake128 {}
 
+#[cfg(feature = "shake")]
 impl KdfTrait for KdfShake128 {
     // From <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-1>
     const KDF_ID: u16 = 0x0010;
@@ -284,7 +304,7 @@ impl KdfTrait for KdfShake128 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         one_stage_kdf::extract_and_expand::<Shake128>(ikm, suite_id, info, out);
         Ok(())
     }
@@ -311,9 +331,11 @@ impl KdfTrait for KdfShake128 {
     }
 }
 
+#[cfg(feature = "shake")]
 /// The implementation of SHAKE256 KDF
 pub struct KdfShake256 {}
 
+#[cfg(feature = "shake")]
 impl KdfTrait for KdfShake256 {
     // From <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-1>
     const KDF_ID: u16 = 0x0011;
@@ -337,7 +359,7 @@ impl KdfTrait for KdfShake256 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         one_stage_kdf::extract_and_expand::<Shake256>(ikm, suite_id, info, out);
         Ok(())
     }
@@ -364,9 +386,11 @@ impl KdfTrait for KdfShake256 {
     }
 }
 
+#[cfg(feature = "shake")]
 /// The implementation of TurboSHAKE128 KDF
 pub struct KdfTurboShake128 {}
 
+#[cfg(feature = "shake")]
 impl KdfTrait for KdfTurboShake128 {
     // From <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-1>
     const KDF_ID: u16 = 0x0012;
@@ -390,7 +414,7 @@ impl KdfTrait for KdfTurboShake128 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         one_stage_kdf::extract_and_expand::<TurboShake128>(ikm, suite_id, info, out);
         Ok(())
     }
@@ -419,9 +443,11 @@ impl KdfTrait for KdfTurboShake128 {
     }
 }
 
+#[cfg(feature = "shake")]
 /// The implementation of TurboSHAKE256 KDF
 pub struct KdfTurboShake256 {}
 
+#[cfg(feature = "shake")]
 impl KdfTrait for KdfTurboShake256 {
     // From <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-1>
     const KDF_ID: u16 = 0x0013;
@@ -445,7 +471,7 @@ impl KdfTrait for KdfTurboShake256 {
         suite_id: &[u8],
         info: &[u8],
         out: &mut [u8],
-    ) -> Result<(), hkdf::InvalidLength> {
+    ) -> Result<(), HpkeError> {
         one_stage_kdf::extract_and_expand::<TurboShake256>(ikm, suite_id, info, out);
         Ok(())
     }

--- a/src/kdf/two_stage_kdf.rs
+++ b/src/kdf/two_stage_kdf.rs
@@ -25,13 +25,13 @@ use sha2::digest::{Digest, OutputSizeUser};
 /// info string, to expand to the output buffer. Uses HKDF rather than XOF.
 ///
 /// If `out.len()` is more than 255x the digest size (in bytes) of the underlying hash function,
-/// returns an `Err(hkdf::InvalidLength)`.
+/// returns an `Err(HpkeError::KdfOutputTooLong)`.
 pub(crate) fn extract_and_expand<H>(
     ikm: &[u8],
     suite_id: &[u8],
     info: &[u8],
     out: &mut [u8],
-) -> Result<(), hkdf::InvalidLength>
+) -> Result<(), HpkeError>
 where
     H: Clone + Digest + EagerHash,
 {
@@ -39,6 +39,7 @@ where
     let (_, hkdf_ctx) = labeled_extract::<H>(&[], suite_id, b"eae_prk", ikm);
     // Expand using given info string
     labeled_expand(&hkdf_ctx, suite_id, b"shared_secret", info, out)
+        .map_err(|hkdf::InvalidLength| HpkeError::KdfOutputTooLong)
 }
 
 // RFC 9180 §4

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -13,35 +13,25 @@ use rand_core::UnwrapErr;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
-#[cfg(any(
-    feature = "x25519",
-    feature = "p256",
-    feature = "p384",
-    feature = "p521"
-))]
+#[cfg(any(feature = "x25519", feature = "nistp"))]
 mod dhkem;
-#[cfg(any(
-    feature = "x25519",
-    feature = "p256",
-    feature = "p384",
-    feature = "p521"
-))]
+#[cfg(any(feature = "x25519", feature = "nistp"))]
 pub use dhkem::*;
-#[cfg(any(feature = "mlkem768p256", feature = "mlkem1024p384"))]
+#[cfg(all(feature = "mlkem", feature = "nistp"))]
 mod mlkem_nistp;
-#[cfg(feature = "mlkem1024p384")]
+#[cfg(all(feature = "mlkem", feature = "nistp"))]
 pub use mlkem_nistp::mlkem1024p384::MlKem1024P384;
-#[cfg(feature = "mlkem768p256")]
+#[cfg(all(feature = "mlkem", feature = "nistp"))]
 pub use mlkem_nistp::mlkem768p256::MlKem768P256;
-#[cfg(any(feature = "mlkem768", feature = "mlkem1024"))]
+#[cfg(feature = "mlkem")]
 pub(crate) mod mlkem;
-#[cfg(feature = "mlkem1024")]
+#[cfg(feature = "mlkem")]
 pub use mlkem::mlkem1024::MlKem1024;
-#[cfg(feature = "mlkem768")]
+#[cfg(feature = "mlkem")]
 pub use mlkem::mlkem768::MlKem768;
-#[cfg(feature = "xwing")]
+#[cfg(feature = "mlkem")]
 pub(crate) mod xwing;
-#[cfg(feature = "xwing")]
+#[cfg(all(feature = "mlkem", feature = "x25519"))]
 pub use xwing::XWing;
 
 /// Represents authenticated encryption functionality
@@ -193,7 +183,7 @@ mod tests {
     use crate::{kem::Kem as KemTrait, Deserializable, Serializable};
 
     macro_rules! test_encap_correctness {
-        ($test_name:ident, $kem_ty:ty) => {
+        ($test_name:ident, $kem_ty:ty, $use_auth:literal) => {
             /// Tests that encap and decap produce the same shared secret when composed
             #[test]
             fn $test_name() {
@@ -216,24 +206,25 @@ mod tests {
                 //
                 // Now do it with the auth, i.e., using the sender's identity keys
                 //
+                if $use_auth {
+                    // Make a sender identity keypair
+                    let (sk_sender_id, pk_sender_id) = Kem::gen_keypair_with_rng(&mut csprng);
 
-                // Make a sender identity keypair
-                let (sk_sender_id, pk_sender_id) = Kem::gen_keypair_with_rng(&mut csprng);
+                    // Encapsulate a random shared secret
+                    let (auth_shared_secret, encapped_key) = Kem::encap_with_rng(
+                        &pk_recip,
+                        Some((&sk_sender_id, &pk_sender_id.clone())),
+                        &mut csprng,
+                    )
+                    .unwrap();
 
-                // Encapsulate a random shared secret
-                let (auth_shared_secret, encapped_key) = Kem::encap_with_rng(
-                    &pk_recip,
-                    Some((&sk_sender_id, &pk_sender_id.clone())),
-                    &mut csprng,
-                )
-                .unwrap();
+                    // Decap it
+                    let decapped_auth_shared_secret =
+                        Kem::decap(&sk_recip, Some(&pk_sender_id), &encapped_key).unwrap();
 
-                // Decap it
-                let decapped_auth_shared_secret =
-                    Kem::decap(&sk_recip, Some(&pk_sender_id), &encapped_key).unwrap();
-
-                // Ensure that the encapsulated secret is what decap() derives
-                assert_eq!(auth_shared_secret.0, decapped_auth_shared_secret.0);
+                    // Ensure that the encapsulated secret is what decap() derives
+                    assert_eq!(auth_shared_secret.0, decapped_auth_shared_secret.0);
+                }
             }
         };
     }
@@ -260,8 +251,10 @@ mod tests {
                     )
                     .unwrap();
 
+                // Now serialize again
                 assert_eq!(
-                    new_encapped_key.0, encapped_key.0,
+                    new_encapped_key.to_bytes(),
+                    encapped_key_bytes,
                     "encapped key doesn't serialize correctly"
                 );
             }
@@ -271,32 +264,57 @@ mod tests {
     #[cfg(feature = "x25519")]
     mod x25519_tests {
         use super::*;
+        use crate::kem::*;
 
-        test_encap_correctness!(test_encap_correctness_x25519, crate::kem::X25519HkdfSha256);
-        test_encapped_serialize!(test_encapped_serialize_x25519, crate::kem::X25519HkdfSha256);
+        test_encap_correctness!(test_encap_correctness_x25519, X25519HkdfSha256, true);
+        test_encapped_serialize!(test_encapped_serialize_x25519, X25519HkdfSha256);
     }
 
-    #[cfg(feature = "p256")]
-    mod p256_tests {
+    #[cfg(feature = "nistp")]
+    mod nistp_test {
         use super::*;
+        use crate::kem::*;
 
-        test_encap_correctness!(test_encap_correctness_p256, crate::kem::DhP256HkdfSha256);
-        test_encapped_serialize!(test_encapped_serialize_p256, crate::kem::DhP256HkdfSha256);
+        test_encap_correctness!(test_encap_correctness_p256, DhP256HkdfSha256, true);
+        test_encapped_serialize!(test_encapped_serialize_p256, DhP256HkdfSha256);
+
+        test_encap_correctness!(test_encap_correctness_p384, DhP384HkdfSha384, true);
+        test_encapped_serialize!(test_encapped_serialize_p384, DhP384HkdfSha384);
+
+        test_encap_correctness!(test_encap_correctness_p521, DhP521HkdfSha512, true);
+        test_encapped_serialize!(test_encapped_serialize_p521, DhP521HkdfSha512);
     }
 
-    #[cfg(feature = "p384")]
-    mod p384_tests {
+    #[cfg(feature = "mlkem")]
+    mod mlkem_test {
         use super::*;
+        use crate::kem::*;
 
-        test_encap_correctness!(test_encap_correctness_p384, crate::kem::DhP384HkdfSha384);
-        test_encapped_serialize!(test_encapped_serialize_p384, crate::kem::DhP384HkdfSha384);
+        test_encap_correctness!(test_encap_correctness_mlkem768, MlKem768, false);
+        test_encapped_serialize!(test_encapped_serialize_mlkem768, MlKem768);
+
+        test_encap_correctness!(test_encap_correctness_mlkem1024, MlKem1024, false);
+        test_encapped_serialize!(test_encapped_serialize_mlkem1024, MlKem1024);
     }
 
-    #[cfg(feature = "p521")]
-    mod p521_tests {
+    #[cfg(all(feature = "mlkem", feature = "nistp"))]
+    mod mlkem_nistp_test {
         use super::*;
+        use crate::kem::*;
 
-        test_encap_correctness!(test_encap_correctness_p521, crate::kem::DhP521HkdfSha512);
-        test_encapped_serialize!(test_encapped_serialize_p521, crate::kem::DhP521HkdfSha512);
+        test_encap_correctness!(test_encap_correctness_mlkem768p256, MlKem768P256, false);
+        test_encapped_serialize!(test_encapped_serialize_mlkem768p256, MlKem768P256);
+
+        test_encap_correctness!(test_encap_correctness_mlkem1024p384, MlKem1024P384, false);
+        test_encapped_serialize!(test_encapped_serialize_mlkem1024p384, MlKem1024P384);
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "x25519"))]
+    mod xwing_test {
+        use super::*;
+        use crate::kem::*;
+
+        test_encap_correctness!(test_encap_correctness_xwing, XWing, false);
+        test_encapped_serialize!(test_encapped_serialize_xwing, XWing);
     }
 }

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -29,7 +29,7 @@ pub(crate) mod mlkem;
 pub use mlkem::mlkem1024::MlKem1024;
 #[cfg(feature = "mlkem")]
 pub use mlkem::mlkem768::MlKem768;
-#[cfg(feature = "mlkem")]
+#[cfg(all(feature = "mlkem", feature = "x25519"))]
 pub(crate) mod xwing;
 #[cfg(all(feature = "mlkem", feature = "x25519"))]
 pub use xwing::XWing;

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -11,6 +11,7 @@ macro_rules! impl_dhkem {
         $kdf:ty,
         $kem_id:literal,
     ) => {
+        // We do feature flags as a param because then it shows up in our docs
         #[cfg(feature = $feature_flag)]
         pub use $mod_name::$kem_name;
 

--- a/src/kem/dhkem.rs
+++ b/src/kem/dhkem.rs
@@ -419,43 +419,43 @@ macro_rules! impl_dhkem {
 // Implement DHKEM(X25519, HKDF-SHA256)
 impl_dhkem!(
     #[doc = "DHKEM(X25519, HKDF-SHA256) classical KEM"],
-    "x25519",
-    x25519_hkdfsha256,
-    X25519HkdfSha256,
-    crate::dhkex::x25519::X25519,
-    crate::kdf::HkdfSha256,
-    0x0020,
+    "x25519",                     // feature_flag
+    x25519_hkdfsha256,            // mod_name
+    X25519HkdfSha256,             // kem_name
+    crate::dhkex::x25519::X25519, // dhkex
+    crate::kdf::HkdfSha256,       // kdf
+    0x0020,                       // kem_id
 );
 
 // Implement DHKEM(P-256, HKDF-SHA256)
 impl_dhkem!(
     #[doc = "DHKEM(P-256, HKDF-SHA256) classical KEM"],
-    "p256",
-    dhp256_hkdfsha256,
-    DhP256HkdfSha256,
-    crate::dhkex::ecdh_nistp::p256::DhP256,
-    crate::kdf::HkdfSha256,
-    0x0010,
+    "nistp",                                // feature_flag
+    dhp256_hkdfsha256,                      // mod_name
+    DhP256HkdfSha256,                       // kem_name
+    crate::dhkex::ecdh_nistp::p256::DhP256, // dhkex
+    crate::kdf::HkdfSha256,                 // kdf
+    0x0010,                                 // kem_id
 );
 
 // Implement DHKEM(P-384, HKDF-SHA384)
 impl_dhkem!(
     #[doc = "DHKEM(P-384, HKDF-SHA384) classical KEM"],
-    "p384",
-    dhp384_hkdfsha384,
-    DhP384HkdfSha384,
-    crate::dhkex::ecdh_nistp::p384::DhP384,
-    crate::kdf::HkdfSha384,
-    0x0011,
+    "nistp",                                // feature_flag
+    dhp384_hkdfsha384,                      // mod_name
+    DhP384HkdfSha384,                       // kem_name
+    crate::dhkex::ecdh_nistp::p384::DhP384, // dhkex
+    crate::kdf::HkdfSha384,                 // kdf
+    0x0011,                                 // kem_id
 );
 
 // Implement DHKEM(P-521, HKDF-SHA512)
 impl_dhkem!(
     #[doc = "DHKEM(P-521, HKDF-SHA512) classical KEM"],
-    "p521",
-    dhp521_hkdfsha512,
-    DhP521HkdfSha512,
-    crate::dhkex::ecdh_nistp::p521::DhP521,
-    crate::kdf::HkdfSha512,
-    0x0012,
+    "nistp",                                // feature_flag
+    dhp521_hkdfsha512,                      // mod_name
+    DhP521HkdfSha512,                       // kem_name
+    crate::dhkex::ecdh_nistp::p521::DhP521, // dhkex
+    crate::kdf::HkdfSha512,                 // kdf
+    0x0012,                                 // kem_id
 );

--- a/src/kem/mlkem.rs
+++ b/src/kem/mlkem.rs
@@ -273,7 +273,6 @@ macro_rules! define_mlkem {
 
 // kem_id is from <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-2>
 
-#[cfg(feature = "mlkem768")]
 define_mlkem!(
     #[doc = "ML-KEM 768 post-quantum KEM"],
     mlkem768,         // mod_name
@@ -282,7 +281,6 @@ define_mlkem!(
     0x0041,           // kem_id
 );
 
-#[cfg(feature = "mlkem1024")]
 define_mlkem!(
     #[doc = "ML-KEM 1024 post-quantum KEM"],
     mlkem1024,         // mod_name
@@ -293,9 +291,7 @@ define_mlkem!(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "mlkem1024")]
     use super::mlkem1024::MlKem1024;
-    #[cfg(feature = "mlkem768")]
     use super::mlkem768::MlKem768;
     use crate::{Deserializable, Kem as KemTrait, Serializable};
 
@@ -347,17 +343,12 @@ mod tests {
         };
     }
 
-    #[cfg(feature = "mlkem768")]
     test_encap_correctness!(test_encap_correctness_mlkem768, MlKem768);
-    #[cfg(feature = "mlkem1024")]
     test_encap_correctness!(test_encap_correctness_mlkem1024, MlKem1024);
-    #[cfg(feature = "mlkem768")]
     test_encapped_serialize!(test_encapped_serialize_mlkem768, MlKem768);
-    #[cfg(feature = "mlkem1024")]
     test_encapped_serialize!(test_encapped_serialize_mlkem1024, MlKem1024);
 
     /// Tests that the wire sizes match the constants in <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-2>
-    #[cfg(feature = "mlkem768")]
     #[test]
     fn sizes_match_spec_mlkem768() {
         // ML-KEM-768: KEM_ID=0x0041, Nsecret=32, Nenc=1088, Npk=1184, Nsk=64
@@ -368,7 +359,6 @@ mod tests {
     }
 
     /// Tests that the wire sizes match the constants in draft-ietf-hpke-pq-04 §3
-    #[cfg(feature = "mlkem1024")]
     #[test]
     fn sizes_match_spec_mlkem1024() {
         // ML-KEM-1024: KEM_ID=0x0042, Nsecret=32, Nenc=1568, Npk=1568, Nsk=64
@@ -379,7 +369,6 @@ mod tests {
     }
 
     /// Tests that DeriveKeyPair is deterministic and that derived keypairs round-trip
-    #[cfg(feature = "mlkem768")]
     #[test]
     fn derive_keypair_roundtrip() {
         let ikm = [7u8; 64];

--- a/src/kem/mlkem_nistp.rs
+++ b/src/kem/mlkem_nistp.rs
@@ -529,7 +529,7 @@ macro_rules! impl_mlkem_nistp {
 // kem_id from <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-3>
 // seed_t_len from <https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html#section-3.1.1>
 
-#[cfg(feature = "mlkem768p256")]
+#[cfg(all(feature = "mlkem", feature = "nistp"))]
 impl_mlkem_nistp!(
     #[doc = "ML-KEM 768 + P256 hybrid post-quantum KEM"],
     mlkem768p256, // mod_name
@@ -544,7 +544,7 @@ impl_mlkem_nistp!(
     32                // scalar_len
 );
 
-#[cfg(feature = "mlkem1024p384")]
+#[cfg(all(feature = "mlkem", feature = "nistp"))]
 impl_mlkem_nistp!(
     #[doc = "ML-KEM 1024 + P384 hybrid post-quantum KEM"],
     mlkem1024p384,     // mod_name

--- a/src/kem/mlkem_nistp.rs
+++ b/src/kem/mlkem_nistp.rs
@@ -529,6 +529,8 @@ macro_rules! impl_mlkem_nistp {
 // kem_id from <https://www.ietf.org/archive/id/draft-ietf-hpke-pq-04.html#table-3>
 // seed_t_len from <https://www.ietf.org/archive/id/draft-irtf-cfrg-concrete-hybrid-kems-03.html#section-3.1.1>
 
+// The cfgs here are redundant. We keep them bc it makes the docs show the feature gates properly
+
 #[cfg(all(feature = "mlkem", feature = "nistp"))]
 impl_mlkem_nistp!(
     #[doc = "ML-KEM 768 + P256 hybrid post-quantum KEM"],

--- a/src/kem/xwing.rs
+++ b/src/kem/xwing.rs
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         let mut csprng = rand::rng();
-        let (sk, pk) = XWing::gen_keypair();
+        let (sk, pk) = XWing::gen_keypair_with_rng(&mut csprng);
         let (shared_secret, encapped_key) =
             XWing::encap_with_rng(&pk, None, &mut csprng).expect("encapsulation failed");
         let shared_secret_recipient =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,14 @@ mod kat_tests;
 #[cfg(test)]
 mod test_util;
 
+//-------- Feature flag validation --------//
+
+#[cfg(not(any(feature = "x25519", feature = "nistp", feature = "mlkem")))]
+compile_error!("At least one KEM feature must be enabled: `x25519`, `nistp`, or `mlkem`");
+
+#[cfg(not(any(feature = "aes", feature = "chacha")))]
+compile_error!("At least one AEAD feature must be enabled: `aes` or `chacha`");
+
 //-------- Modules and exports--------//
 
 // Re-export our versions of hybrid_array, rand_core, and inout, since their traits and types are
@@ -107,12 +115,7 @@ pub use rand_core;
 mod util;
 
 pub mod aead;
-#[cfg(any(
-    feature = "x25519",
-    feature = "p256",
-    feature = "p384",
-    feature = "p521"
-))]
+#[cfg(any(feature = "x25519", feature = "nistp"))]
 mod dhkex;
 pub mod kdf;
 pub mod kem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,28 +9,34 @@
 //! ```
 //! # #[cfg(all(feature = "alloc", feature = "x25519", feature = "chacha", feature = "getrandom"))]
 //! # {
-//! # use hpke::{
-//! #     aead::ChaCha20Poly1305,
-//! #     kdf::HkdfSha384,
-//! #     kem::X25519HkdfSha256,
-//! #     Kem as KemTrait, OpModeR, OpModeS, setup_receiver, setup_sender,
-//! # };
+//! use hpke::{
+//!     aead::ChaCha20Poly1305,
+//!     kdf::KdfTurboShake128,
+//!     kem::XWing,
+//!     Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable, setup_receiver,
+//!     setup_sender,
+//! };
 //! // These types define the ciphersuite Alice and Bob will be using
-//! type Kem = X25519HkdfSha256;
+//! type Kem = XWing;
 //! type Aead = ChaCha20Poly1305;
-//! type Kdf = HkdfSha384;
+//! type Kdf = KdfTurboShake128;
 //!
 //! // Bob generates his keypair
 //! let (bob_sk, bob_pk) = Kem::gen_keypair();
+//! let bob_pk_bytes = bob_pk.to_bytes();
 //!
 //! // This is a description string for the session. Both Alice and Bob need to know this value.
 //! // It's not secret.
 //! let info_str = b"Alice and Bob's weekly chat";
 //!
+//! // Alice downloads Bob's public key from a trusted source and deserializes it
+//! let bob_pk = <Kem as KemTrait>::PublicKey::from_bytes(&bob_pk_bytes)
+//!     .expect("Bob's pk is invalid");
+//!
 //! // Alice initiates a session with Bob. OpModeS::Base means that Alice is not authenticating
-//! // herself at all. If she had a public key herself, or a pre-shared secret that Bob also
-//! // knew, she'd be able to authenticate herself. See the OpModeS and OpModeR types for more
-//! // detail.
+//! // herself at all. If she had a public key herself (and was using an elliptic curve KEM), or
+//! // had a pre-shared secret that Bob also knew, she'd be able to authenticate herself. See the
+//! // OpModeS and OpModeR types for more detail.
 //! let (encapsulated_key, mut encryption_context) =
 //!     hpke::setup_sender::<Aead, Kdf, Kem>(&OpModeS::Base, &bob_pk, info_str)
 //!         .expect("invalid server pubkey!");
@@ -43,7 +49,7 @@
 //! //   use hpke::inout::InOutBuf;
 //! //   let auth_tag = encryption_context.seal_inout_detached(InOutBuf::from(&mut msg), aad)?;
 //! // To seal with allocating:
-//! let ciphertext = encryption_context.seal(msg, aad).expect("encryption failed!");
+//! let ciphertext: Vec<u8> = encryption_context.seal(msg, aad).expect("encryption failed!");
 //!
 //! // ~~~
 //! // Alice sends the encapsulated key, message ciphertext, AAD, and auth tag to Bob over the

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -187,7 +187,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{setup_receiver, setup_sender_with_rng};
-    #[cfg(feature = "hkdf")]
+    #[cfg(feature = "hkdfsha2")]
     use crate::kdf::HkdfSha256;
     use crate::kem::Kem as KemTrait;
     use crate::test_util::{aead_ctx_eq, gen_rand_buf, new_op_mode_pair, OpModeKind};

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -199,7 +199,7 @@ mod test {
     /// testing that `gen_ctx_kem_pair` returns identical encryption contexts
     #[cfg(feature = "chacha")]
     macro_rules! test_setup_correctness {
-        ($test_name:ident, $aead_ty:ty, $kdf_ty:ty, $kem_ty:ty) => {
+        ($test_name:ident, $aead_ty:ty, $kdf_ty:ty, $kem_ty:ty, $use_auth:expr) => {
             #[test]
             fn $test_name() {
                 type A = $aead_ty;
@@ -213,13 +213,20 @@ mod test {
                 // Generate the receiver's long-term keypair
                 let (sk_recip, pk_recip) = Kem::gen_keypair_with_rng(&mut csprng);
 
-                // Try a full setup for all the op modes
-                for op_mode_kind in &[
-                    OpModeKind::Base,
-                    OpModeKind::Auth,
-                    OpModeKind::Psk,
-                    OpModeKind::AuthPsk,
-                ] {
+                // Build the list of modes to test. PQ KEMs don't support Auth/AuthPsk.
+                let op_mode_kinds: &[OpModeKind] = if $use_auth {
+                    &[
+                        OpModeKind::Base,
+                        OpModeKind::Psk,
+                        OpModeKind::Auth,
+                        OpModeKind::AuthPsk,
+                    ]
+                } else {
+                    &[OpModeKind::Base, OpModeKind::Psk]
+                };
+
+                // Try a full setup for the chosen op modes
+                for op_mode_kind in op_mode_kinds {
                     // Generate a mutually agreeing op mode pair
                     let (psk, psk_id) = (gen_rand_buf(), gen_rand_buf());
                     let (sender_mode, receiver_mode) =
@@ -253,7 +260,7 @@ mod test {
     /// Tests that using different input data gives you different encryption contexts
     #[cfg(feature = "chacha")]
     macro_rules! test_setup_soundness {
-        ($test_name:ident, $aead:ty, $kdf:ty, $kem:ty) => {
+        ($test_name:ident, $aead:ty, $kdf:ty, $kem:ty, $use_auth:expr) => {
             #[test]
             fn $test_name() {
                 type A = $aead;
@@ -343,13 +350,15 @@ mod test {
             test_setup_correctness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            X25519HkdfSha256
+            X25519HkdfSha256,
+            true
         );
         test_setup_soundness!(
             test_setup_soundness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            X25519HkdfSha256
+            X25519HkdfSha256,
+            true
         );
     }
 
@@ -365,39 +374,144 @@ mod test {
             test_setup_correctness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            DhP256HkdfSha256
+            DhP256HkdfSha256,
+            true
         );
         test_setup_soundness!(
             test_setup_soundness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            DhP256HkdfSha256
+            DhP256HkdfSha256,
+            true
         );
 
         test_setup_correctness!(
             test_setup_correctness_p384,
             ChaCha20Poly1305,
             HkdfSha384,
-            DhP384HkdfSha384
+            DhP384HkdfSha384,
+            true
         );
         test_setup_soundness!(
             test_setup_soundness_p384,
             ChaCha20Poly1305,
             HkdfSha384,
-            DhP384HkdfSha384
+            DhP384HkdfSha384,
+            true
         );
 
         test_setup_correctness!(
             test_setup_correctness_p521,
             ChaCha20Poly1305,
             HkdfSha512,
-            DhP521HkdfSha512
+            DhP521HkdfSha512,
+            true
         );
         test_setup_soundness!(
             test_setup_soundness_p521,
             ChaCha20Poly1305,
             HkdfSha512,
-            DhP521HkdfSha512
+            DhP521HkdfSha512,
+            true
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "chacha"))]
+    mod mlkem_tests {
+        use super::*;
+        use crate::{
+            kdf::{KdfShake128, KdfShake256},
+            kem::*,
+        };
+
+        test_setup_correctness!(
+            test_setup_correctness_mlkem768,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768,
+            false
+        );
+        test_setup_soundness!(
+            test_setup_soundness_mlkem768,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768,
+            false
+        );
+
+        test_setup_correctness!(
+            test_setup_correctness_mlkem1024,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024,
+            false
+        );
+        test_setup_soundness!(
+            test_setup_soundness_mlkem1024,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024,
+            false
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "nistp", feature = "chacha"))]
+    mod mlkem_nistp_tests {
+        use super::*;
+        use crate::{
+            kdf::{KdfShake128, KdfShake256},
+            kem::*,
+        };
+
+        test_setup_correctness!(
+            test_setup_correctness_mlkem768p256,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768P256,
+            false
+        );
+        test_setup_soundness!(
+            test_setup_soundness_mlkem768p256,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768P256,
+            false
+        );
+
+        test_setup_correctness!(
+            test_setup_correctness_mlkem1024p384,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024P384,
+            false
+        );
+        test_setup_soundness!(
+            test_setup_soundness_mlkem1024p384,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024P384,
+            false
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "x25519", feature = "chacha"))]
+    mod xwing_tests {
+        use super::*;
+        use crate::{kdf::KdfTurboShake128, kem::*};
+
+        test_setup_correctness!(
+            test_setup_correctness_xwing,
+            ChaCha20Poly1305,
+            KdfTurboShake128,
+            XWing,
+            false
+        );
+        test_setup_soundness!(
+            test_setup_soundness_xwing,
+            ChaCha20Poly1305,
+            KdfTurboShake128,
+            XWing,
+            false
         );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -187,8 +187,10 @@ where
 #[cfg(test)]
 mod test {
     use super::{setup_receiver, setup_sender_with_rng};
+    #[cfg(feature = "hkdf")]
+    use crate::kdf::HkdfSha256;
+    use crate::kem::Kem as KemTrait;
     use crate::test_util::{aead_ctx_eq, gen_rand_buf, new_op_mode_pair, OpModeKind};
-    use crate::{kdf::HkdfSha256, kem::Kem as KemTrait};
 
     #[cfg(feature = "chacha")]
     use crate::aead::ChaCha20Poly1305;
@@ -335,74 +337,67 @@ mod test {
     #[cfg(all(feature = "x25519", feature = "chacha"))]
     mod x25519_tests {
         use super::*;
+        use crate::kem::*;
 
         test_setup_correctness!(
             test_setup_correctness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::x25519_hkdfsha256::X25519HkdfSha256
+            X25519HkdfSha256
         );
         test_setup_soundness!(
             test_setup_soundness_x25519,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::x25519_hkdfsha256::X25519HkdfSha256
+            X25519HkdfSha256
         );
     }
 
-    #[cfg(all(feature = "p256", feature = "chacha"))]
-    mod p256_tests {
+    #[cfg(all(feature = "nistp", feature = "chacha"))]
+    mod nistp_tests {
         use super::*;
+        use crate::{
+            kdf::{HkdfSha384, HkdfSha512},
+            kem::*,
+        };
 
         test_setup_correctness!(
             test_setup_correctness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256
+            DhP256HkdfSha256
         );
         test_setup_soundness!(
             test_setup_soundness_p256,
             ChaCha20Poly1305,
             HkdfSha256,
-            crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256
+            DhP256HkdfSha256
         );
-    }
-
-    #[cfg(all(feature = "p384", feature = "chacha"))]
-    mod p384_tests {
-        use super::*;
-        use crate::kdf::HkdfSha384;
 
         test_setup_correctness!(
             test_setup_correctness_p384,
             ChaCha20Poly1305,
             HkdfSha384,
-            crate::kem::dhp384_hkdfsha384::DhP384HkdfSha384
+            DhP384HkdfSha384
         );
         test_setup_soundness!(
             test_setup_soundness_p384,
             ChaCha20Poly1305,
             HkdfSha384,
-            crate::kem::dhp384_hkdfsha384::DhP384HkdfSha384
+            DhP384HkdfSha384
         );
-    }
-
-    #[cfg(all(feature = "p521", feature = "chacha"))]
-    mod p521_tests {
-        use super::*;
-        use crate::kdf::HkdfSha512;
 
         test_setup_correctness!(
             test_setup_correctness_p521,
             ChaCha20Poly1305,
             HkdfSha512,
-            crate::kem::dhp521_hkdfsha512::DhP521HkdfSha512
+            DhP521HkdfSha512
         );
         test_setup_soundness!(
             test_setup_soundness_p521,
             ChaCha20Poly1305,
             HkdfSha512,
-            crate::kem::dhp521_hkdfsha512::DhP521HkdfSha512
+            DhP521HkdfSha512
         );
     }
 }

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -226,7 +226,8 @@ where
 mod test {
     use super::*;
     use crate::{
-        kem::Kem as KemTrait,
+        kdf::*,
+        kem::{Kem as KemTrait, *},
         op_mode::{OpModeR, OpModeS, PskBundle},
         test_util::gen_rand_buf,
     };
@@ -308,71 +309,71 @@ mod test {
     test_single_shot_correctness!(
         test_single_shot_correctness_x25519,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::x25519_hkdfsha256::X25519HkdfSha256,
+        HkdfSha256,
+        X25519HkdfSha256,
         true
     );
 
-    #[cfg(all(feature = "p256", feature = "chacha"))]
+    #[cfg(all(feature = "nistp", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_p256,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::dhp256_hkdfsha256::DhP256HkdfSha256,
+        HkdfSha256,
+        DhP256HkdfSha256,
         true
     );
 
-    #[cfg(all(feature = "p384", feature = "chacha"))]
+    #[cfg(all(feature = "nistp", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_p384,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha384,
-        crate::kem::dhp384_hkdfsha384::DhP384HkdfSha384,
+        HkdfSha384,
+        DhP384HkdfSha384,
         true
     );
 
-    #[cfg(all(feature = "p521", feature = "chacha"))]
+    #[cfg(all(feature = "nistp", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_p521,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha512,
-        crate::kem::dhp521_hkdfsha512::DhP521HkdfSha512,
+        HkdfSha512,
+        DhP521HkdfSha512,
         true
     );
 
-    #[cfg(feature = "xwing")]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_xwing,
-        ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::xwing::XWing,
-        false
-    );
-
-    #[cfg(all(feature = "mlkem768", feature = "chacha"))]
+    #[cfg(all(feature = "mlkem", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_mlkem768,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::mlkem::mlkem768::MlKem768,
+        KdfShake128,
+        MlKem768,
         false
     );
 
-    #[cfg(all(feature = "mlkem1024", feature = "chacha"))]
+    #[cfg(all(feature = "mlkem", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_mlkem1024,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::mlkem::mlkem1024::MlKem1024,
+        KdfShake256,
+        MlKem1024,
         false
     );
 
-    #[cfg(all(feature = "mlkem1024p384", feature = "chacha"))]
+    #[cfg(all(feature = "mlkem", feature = "nistp", feature = "chacha"))]
     test_single_shot_correctness!(
         test_single_shot_correctness_mlkem1024p384,
         ChaCha20Poly1305,
-        crate::kdf::HkdfSha256,
-        crate::kem::MlKem1024P384,
+        KdfShake256,
+        MlKem1024P384,
+        false
+    );
+
+    #[cfg(all(feature = "mlkem", feature = "x25519", feature = "chacha"))]
+    test_single_shot_correctness!(
+        test_single_shot_correctness_xwing,
+        ChaCha20Poly1305,
+        KdfTurboShake128,
+        XWing,
         false
     );
 }

--- a/src/single_shot.rs
+++ b/src/single_shot.rs
@@ -306,74 +306,95 @@ mod test {
     }
 
     #[cfg(all(feature = "x25519", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_x25519,
-        ChaCha20Poly1305,
-        HkdfSha256,
-        X25519HkdfSha256,
-        true
-    );
+    mod x25519_tests {
+        use super::*;
+
+        test_single_shot_correctness!(
+            test_single_shot_correctness_x25519,
+            ChaCha20Poly1305,
+            HkdfSha256,
+            X25519HkdfSha256,
+            true
+        );
+    }
 
     #[cfg(all(feature = "nistp", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_p256,
-        ChaCha20Poly1305,
-        HkdfSha256,
-        DhP256HkdfSha256,
-        true
-    );
+    mod nistp_tests {
+        use super::*;
 
-    #[cfg(all(feature = "nistp", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_p384,
-        ChaCha20Poly1305,
-        HkdfSha384,
-        DhP384HkdfSha384,
-        true
-    );
-
-    #[cfg(all(feature = "nistp", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_p521,
-        ChaCha20Poly1305,
-        HkdfSha512,
-        DhP521HkdfSha512,
-        true
-    );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_p256,
+            ChaCha20Poly1305,
+            HkdfSha256,
+            DhP256HkdfSha256,
+            true
+        );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_p384,
+            ChaCha20Poly1305,
+            HkdfSha384,
+            DhP384HkdfSha384,
+            true
+        );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_p521,
+            ChaCha20Poly1305,
+            HkdfSha512,
+            DhP521HkdfSha512,
+            true
+        );
+    }
 
     #[cfg(all(feature = "mlkem", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_mlkem768,
-        ChaCha20Poly1305,
-        KdfShake128,
-        MlKem768,
-        false
-    );
+    mod mlkem_tests {
+        use super::*;
 
-    #[cfg(all(feature = "mlkem", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_mlkem1024,
-        ChaCha20Poly1305,
-        KdfShake256,
-        MlKem1024,
-        false
-    );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_mlkem768,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768,
+            false
+        );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_mlkem1024,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024,
+            false
+        );
+    }
 
     #[cfg(all(feature = "mlkem", feature = "nistp", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_mlkem1024p384,
-        ChaCha20Poly1305,
-        KdfShake256,
-        MlKem1024P384,
-        false
-    );
+    mod mlkem_nistp_tests {
+        use super::*;
+
+        test_single_shot_correctness!(
+            test_single_shot_correctness_mlkem768p256,
+            ChaCha20Poly1305,
+            KdfShake128,
+            MlKem768P256,
+            false
+        );
+        test_single_shot_correctness!(
+            test_single_shot_correctness_mlkem1024p384,
+            ChaCha20Poly1305,
+            KdfShake256,
+            MlKem1024P384,
+            false
+        );
+    }
 
     #[cfg(all(feature = "mlkem", feature = "x25519", feature = "chacha"))]
-    test_single_shot_correctness!(
-        test_single_shot_correctness_xwing,
-        ChaCha20Poly1305,
-        KdfTurboShake128,
-        XWing,
-        false
-    );
+    mod xwing_tests {
+        use super::*;
+
+        test_single_shot_correctness!(
+            test_single_shot_correctness_xwing,
+            ChaCha20Poly1305,
+            KdfTurboShake128,
+            XWing,
+            false
+        );
+    }
 }

--- a/src/streaming_enc.rs
+++ b/src/streaming_enc.rs
@@ -119,7 +119,7 @@ mod test {
     use super::{
         create_receiver_context, create_sender_context, AeadKey, AeadNonce, ExporterSecret,
     };
-    #[cfg(feature = "hkdf")]
+    #[cfg(feature = "hkdfsha2")]
     use crate::kdf::HkdfSha256;
     use rand_core::Rng;
 

--- a/src/streaming_enc.rs
+++ b/src/streaming_enc.rs
@@ -119,17 +119,15 @@ mod test {
     use super::{
         create_receiver_context, create_sender_context, AeadKey, AeadNonce, ExporterSecret,
     };
-    #[cfg(feature = "hkdfsha2")]
-    use crate::kdf::HkdfSha256;
     use rand_core::Rng;
 
     /// Tests that `open()` can decrypt things properly encrypted with `seal()`
     macro_rules! test_create_ctx_correctness {
-        ($test_name:ident, $aead_ty:ty, $kem_ty:ty) => {
+        ($test_name:ident, $aead_ty:ty, $kdf_ty:ty, $kem_ty:ty) => {
             #[test]
             fn $test_name() {
                 type A = $aead_ty;
-                type Kdf = HkdfSha256;
+                type Kdf = $kdf_ty;
                 type Kem = $kem_ty;
 
                 let mut rng = rand::rng();
@@ -196,15 +194,18 @@ mod test {
     mod x25519_aes_tests {
         use super::*;
         use crate::aead::{AesGcm128, AesGcm256};
+        use crate::kdf::HkdfSha256;
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes128_x25519,
             AesGcm128,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes256_x25519,
             AesGcm256,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
     }
@@ -213,10 +214,12 @@ mod test {
     mod x25519_chacha_tests {
         use super::*;
         use crate::aead::ChaCha20Poly1305;
+        use crate::kdf::HkdfSha256;
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_chacha_x25519,
             ChaCha20Poly1305,
+            HkdfSha256,
             crate::kem::X25519HkdfSha256
         );
     }
@@ -225,27 +228,45 @@ mod test {
     mod nistp_aes_tests {
         use super::*;
         use crate::aead::{AesGcm128, AesGcm256};
+        use crate::kdf::HkdfSha256;
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes128_p256,
             AesGcm128,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes256_p256,
             AesGcm256,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes128_p384,
             AesGcm128,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
         );
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes256_p384,
             AesGcm256,
+            HkdfSha256,
             crate::kem::DhP384HkdfSha384
+        );
+
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_aes128_p521,
+            AesGcm128,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
+        );
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_aes256_p521,
+            AesGcm256,
+            HkdfSha256,
+            crate::kem::DhP521HkdfSha512
         );
     }
 
@@ -253,17 +274,84 @@ mod test {
     mod nistp_chacha_tests {
         use super::*;
         use crate::aead::ChaCha20Poly1305;
+        use crate::kdf::{HkdfSha256, HkdfSha384, HkdfSha512};
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_chacha_p256,
             ChaCha20Poly1305,
+            HkdfSha256,
             crate::kem::DhP256HkdfSha256
         );
-
         test_create_ctx_correctness!(
             test_create_ctx_correctness_chacha_p384,
             ChaCha20Poly1305,
+            HkdfSha384,
             crate::kem::DhP384HkdfSha384
+        );
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_p521,
+            ChaCha20Poly1305,
+            HkdfSha512,
+            crate::kem::DhP521HkdfSha512
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "chacha"))]
+    mod mlkem_tests {
+        use super::*;
+        use crate::aead::ChaCha20Poly1305;
+        use crate::kdf::{KdfShake128, KdfShake256};
+
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_mlkem768,
+            ChaCha20Poly1305,
+            KdfShake128,
+            crate::kem::MlKem768
+        );
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_mlkem1024,
+            ChaCha20Poly1305,
+            KdfShake256,
+            crate::kem::MlKem1024
+        );
+    }
+
+    #[cfg(all(
+        feature = "mlkem",
+        feature = "nistp",
+        feature = "alloc",
+        feature = "chacha"
+    ))]
+    mod mlkem_nistp_tests {
+        use super::*;
+        use crate::aead::ChaCha20Poly1305;
+        use crate::kdf::{KdfShake128, KdfShake256};
+
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_mlkem768p256,
+            ChaCha20Poly1305,
+            KdfShake128,
+            crate::kem::MlKem768P256
+        );
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_mlkem1024p384,
+            ChaCha20Poly1305,
+            KdfShake256,
+            crate::kem::MlKem1024P384
+        );
+    }
+
+    #[cfg(all(feature = "mlkem", feature = "x25519", feature = "chacha"))]
+    mod xwing_tests {
+        use super::*;
+        use crate::aead::ChaCha20Poly1305;
+        use crate::kdf::KdfTurboShake128;
+
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_xwing,
+            ChaCha20Poly1305,
+            KdfTurboShake128,
+            crate::kem::XWing
         );
     }
 }

--- a/src/streaming_enc.rs
+++ b/src/streaming_enc.rs
@@ -119,6 +119,7 @@ mod test {
     use super::{
         create_receiver_context, create_sender_context, AeadKey, AeadNonce, ExporterSecret,
     };
+    #[cfg(feature = "hkdf")]
     use crate::kdf::HkdfSha256;
     use rand_core::Rng;
 
@@ -220,8 +221,8 @@ mod test {
         );
     }
 
-    #[cfg(all(feature = "p256", feature = "alloc", feature = "aes"))]
-    mod p256_aes_tests {
+    #[cfg(all(feature = "nistp", feature = "alloc", feature = "aes"))]
+    mod nistp_aes_tests {
         use super::*;
         use crate::aead::{AesGcm128, AesGcm256};
 
@@ -235,24 +236,7 @@ mod test {
             AesGcm256,
             crate::kem::DhP256HkdfSha256
         );
-    }
 
-    #[cfg(all(feature = "p256", feature = "alloc", feature = "chacha"))]
-    mod p256_chacha_tests {
-        use super::*;
-        use crate::aead::ChaCha20Poly1305;
-
-        test_create_ctx_correctness!(
-            test_create_ctx_correctness_chacha_p256,
-            ChaCha20Poly1305,
-            crate::kem::DhP256HkdfSha256
-        );
-    }
-
-    #[cfg(all(feature = "p384", feature = "alloc", feature = "aes"))]
-    mod p384_aes_tests {
-        use super::*;
-        use crate::aead::{AesGcm128, AesGcm256};
         test_create_ctx_correctness!(
             test_create_ctx_correctness_aes128_p384,
             AesGcm128,
@@ -265,10 +249,16 @@ mod test {
         );
     }
 
-    #[cfg(all(feature = "p384", feature = "alloc", feature = "chacha"))]
-    mod p384_chacha_tests {
+    #[cfg(all(feature = "nistp", feature = "alloc", feature = "chacha"))]
+    mod nistp_chacha_tests {
         use super::*;
         use crate::aead::ChaCha20Poly1305;
+
+        test_create_ctx_correctness!(
+            test_create_ctx_correctness_chacha_p256,
+            ChaCha20Poly1305,
+            crate::kem::DhP256HkdfSha256
+        );
 
         test_create_ctx_correctness!(
             test_create_ctx_correctness_chacha_p384,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,6 +1,7 @@
+#[cfg(any(feature = "x25519", feature = "nistp"))]
+use crate::dhkex::DhKeyExchange;
 use crate::{
     aead::{Aead, AeadCtx, AeadCtxR, AeadCtxS, AeadKey, AeadNonce},
-    dhkex::DhKeyExchange,
     kdf::Kdf as KdfTrait,
     kem::Kem as KemTrait,
     op_mode::{OpModeR, OpModeS, PskBundle},
@@ -22,6 +23,7 @@ pub(crate) fn gen_rand_buf() -> [u8; 32] {
 }
 
 /// Generates a keypair without the need of a KEM
+#[cfg(any(feature = "x25519", feature = "nistp"))]
 pub(crate) fn dhkex_gen_keypair_with_rng<Kex: DhKeyExchange>(
     csprng: &mut impl CryptoRng,
 ) -> (Kex::PrivateKey, Kex::PublicKey) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,7 +73,7 @@ pub(crate) const fn kem_suite_id<Kem: KemTrait>() -> KemSuiteId {
 }
 
 /// Returns a const expression that evaluates to the number of arguments it received
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 macro_rules! count {
     () => (0usize);
     ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
@@ -83,7 +83,7 @@ macro_rules! count {
 /// non-allocating concatenation of the bytestrings. It constructs a big buffer of n*L many bytes
 /// writes everything into there, and keeps track of how many bytes it wrote. The macro returns
 /// `(buf, num_bytes_written)`.
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 macro_rules! concat_with_known_maxlen {
     ( $maxlen:expr, $( $slice:expr ),* ) => {{
         // The length of the big buffer is the number of items we're concatting times the max
@@ -105,7 +105,7 @@ macro_rules! concat_with_known_maxlen {
 
 /// A helper function that writes to a buffer and returns a slice containing the unwritten portion.
 /// If this crate were allowed to use std, we'd just use std::io::Write instead.
-#[cfg(feature = "hkdf")]
+#[cfg(feature = "hkdfsha2")]
 pub(crate) fn write_to_buf<'a>(buf: &'a mut [u8], to_write: &[u8]) -> &'a mut [u8] {
     buf[..to_write.len()].copy_from_slice(to_write);
     &mut buf[to_write.len()..]

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,6 +73,7 @@ pub(crate) const fn kem_suite_id<Kem: KemTrait>() -> KemSuiteId {
 }
 
 /// Returns a const expression that evaluates to the number of arguments it received
+#[cfg(feature = "hkdf")]
 macro_rules! count {
     () => (0usize);
     ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
@@ -82,6 +83,7 @@ macro_rules! count {
 /// non-allocating concatenation of the bytestrings. It constructs a big buffer of n*L many bytes
 /// writes everything into there, and keeps track of how many bytes it wrote. The macro returns
 /// `(buf, num_bytes_written)`.
+#[cfg(feature = "hkdf")]
 macro_rules! concat_with_known_maxlen {
     ( $maxlen:expr, $( $slice:expr ),* ) => {{
         // The length of the big buffer is the number of items we're concatting times the max
@@ -103,6 +105,7 @@ macro_rules! concat_with_known_maxlen {
 
 /// A helper function that writes to a buffer and returns a slice containing the unwritten portion.
 /// If this crate were allowed to use std, we'd just use std::io::Write instead.
+#[cfg(feature = "hkdf")]
 pub(crate) fn write_to_buf<'a>(buf: &'a mut [u8], to_write: &[u8]) -> &'a mut [u8] {
     buf[..to_write.len()].copy_from_slice(to_write);
     &mut buf[to_write.len()..]


### PR DESCRIPTION
The purpose of features is to help the end user know what dependencies they are pulling in and which they can leave out. The current feature system is based on individual ciphersuites, which is not helpful (`mlkem768` uses the same dep as `mlkem1024`).

This PR creates a new set of feature flags which is simplified and more tied to the underyling dependencies. See [`README.md`](https://github.com/rozbb/rust-hpke/blob/7e0c151b4dea73d6d762c273e0f4cb6e2b78990f/README.md) for the overview.

I've also done some housekeeping here and there.