### PR TITLE
Enable zeroization for X-Wing and X25519 secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1248,6 +1249,7 @@ dependencies = [
  "sha3 0.12.0",
  "shake",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1258,6 +1260,7 @@ checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,12 @@ turboshake = { version = "0.7", default-features = false, features = ["zeroize"]
 subtle = { version = "2.6", default-features = false }
 x25519-dalek = { version = "3.0.0", default-features = false, features = [
     "static_secrets",
+    "zeroize",
 ], optional = true }
-x-wing = { version = "0.1.0", optional = true, default-features = false, features = ["hazmat"] }
+x-wing = { version = "0.1.0", optional = true, default-features = false, features = [
+    "hazmat",
+    "zeroize",
+] }
 zeroize = { version = "1", default-features = false, features = [
     "zeroize_derive",
 ] }


### PR DESCRIPTION
## Summary

Enable the `zeroize` features of `x-wing` and `x25519-dalek`.

Without these features, the X-Wing decapsulation seed and the internal X25519 `StaticSecret` / `SharedSecret` values are not zeroized on drop, despite the X25519 wrapper comments stating that the underlying types are zeroize-on-drop.

Both dependencies are updated explicitly because the classical X25519 feature can be enabled without the X-Wing/ML-KEM feature.

Closes #110 