### PR TITLE
Zeroize stack copies in key deserialization and decap

### DIFF
--- a/src/dhkex/x25519.rs
+++ b/src/dhkex/x25519.rs
@@ -7,6 +7,7 @@ use crate::{
 
 use hybrid_array::typenum::{self, Unsigned};
 use subtle::{Choice, ConstantTimeEq};
+use zeroize::Zeroize;
 
 // We wrap the types in order to abstract away the dalek dep
 
@@ -96,7 +97,10 @@ impl Deserializable for PrivateKey {
         // then k = nq for some n > 0. And since k is a multiple of 8 and q is prime, n must be a
         // multiple of 8. However, 8q > 2^257 which is already out of representable range! So k
         // cannot be 0 (mod q).
-        Ok(PrivateKey(x25519_dalek::StaticSecret::from(arr)))
+        let sk = PrivateKey(x25519_dalek::StaticSecret::from(arr));
+        arr.zeroize();
+
+        Ok(sk)
     }
 }
 

--- a/src/kem/mlkem_nistp.rs
+++ b/src/kem/mlkem_nistp.rs
@@ -278,7 +278,7 @@ macro_rules! impl_mlkem_nistp {
                     //       ss_PQ = KEM_PQ.Decaps(dk_PQ, ct_PQ)
                     //       ss_T = Group_T.ElementToSharedSecret(Group_T.Exp(ct_T, dk_T))
                     //       return (ss_PQ, ss_T)
-                    let ss_pq = sk_recip.dk_pq.decapsulate(&encapped_key.ct_pq);
+                    let mut ss_pq = sk_recip.dk_pq.decapsulate(&encapped_key.ct_pq);
                     let ss_t = $curve::ecdh::diffie_hellman(
                         sk_recip.dk_t.to_nonzero_scalar(),
                         ct_t.as_affine(),
@@ -290,6 +290,8 @@ macro_rules! impl_mlkem_nistp {
                         encapped_key.ct_t.as_bytes(),
                         sk_recip.dk_t.public_key().to_sec1_point(false).as_bytes(),
                     );
+
+                    ss_pq.zeroize();
 
                     Ok(SharedSecret(shared_secret))
                 }
@@ -329,7 +331,7 @@ macro_rules! impl_mlkem_nistp {
                     //       ct_T = Group_T.Exp(Group_T.g, sk_E)
                     //       ss_T = Group_T.ElementToSharedSecret(Group_T.Exp(ek_T, sk_E))
                     //       return (ss_PQ, ss_T, ct_PQ, ct_T)
-                    let (ct_pq, ss_pq) = pk_recip.ek_pq.encapsulate_with_rng(csprng);
+                    let (ct_pq, mut ss_pq) = pk_recip.ek_pq.encapsulate_with_rng(csprng);
                     let sk_e = $curve::ecdh::EphemeralSecret::generate_from_rng(csprng);
                     let ct_t = sk_e.public_key().to_sec1_point(false);
                     let ss_t = sk_e.diffie_hellman(&pk_recip.ek_t);
@@ -340,6 +342,8 @@ macro_rules! impl_mlkem_nistp {
                         ct_t.as_bytes(),
                         pk_recip.ek_t.to_sec1_point(false).as_bytes(),
                     );
+
+                    ss_pq.zeroize();
 
                     Ok((SharedSecret(shared_secret), EncappedKey { ct_pq, ct_t }))
                 }

--- a/src/kem/xwing.rs
+++ b/src/kem/xwing.rs
@@ -48,7 +48,10 @@ impl Deserializable for PrivateKey {
         let mut arr = [0u8; Self::OutputSize::USIZE];
         arr.copy_from_slice(encoded);
 
-        Ok(PrivateKey(arr.into()))
+        let sk = PrivateKey(arr.into());
+        arr.zeroize();
+
+        Ok(sk)
     }
 }
 


### PR DESCRIPTION
In the X-Wing and `X25519 PrivateKey::from_bytes`, the fixed-size array is `Copy`, so constructing the key leaves an unzeroized copy of the secret behind. In the ML-KEM/NIST-P hybrids, `ss_pq` is an `Array<u8, U32>`, which is not zeroize-on-drop.

Just a small defense in depth measure.