### PR TITLE
x-wing: Reject non-contributory behaviour in X25519 component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,8 +1241,7 @@ dependencies = [
 [[package]]
 name = "x-wing"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51507b887016c3925c84591108dadb8c099f776eb04fec6a60ae3519fee856f"
+source = "git+https://github.com/str4d/RustCrypto-KEMs.git?rev=f5dd74e238bfebc0b36754923ccc6157d75641e6#f5dd74e238bfebc0b36754923ccc6157d75641e6"
 dependencies = [
  "kem",
  "ml-kem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,6 @@ required-features = ["getrandom"]
 
 [lib]
 bench = false
+
+[patch.crates-io]
+x-wing = { git = "https://github.com/str4d/RustCrypto-KEMs.git", rev = "f5dd74e238bfebc0b36754923ccc6157d75641e6" }

--- a/src/kem/xwing.rs
+++ b/src/kem/xwing.rs
@@ -14,7 +14,7 @@ use hybrid_array::typenum::{Prod, Sum, U3, U32, U64, U1024, Unsigned};
 use rand_core::CryptoRng;
 use shake::Shake256;
 use subtle::{Choice, ConstantTimeEq};
-use x_wing::{Decapsulator, KeyExport, TryKeyInit, kem::Decapsulate};
+use x_wing::{Decapsulator, KeyExport, TryKeyInit, kem::TryDecapsulate};
 use zeroize::Zeroize;
 
 // Type-level size constants for X-Wing
@@ -25,7 +25,7 @@ type U1120 = Sum<Sum<U1024, U64>, U32>;
 const XWING_ENCAP_RANDOMNESS_SIZE: usize = 64;
 
 #[derive(Clone)]
-pub struct PrivateKey(x_wing::DecapsulationKey);
+pub struct PrivateKey(x_wing::DecapsulationKeyRejectNonContrib);
 
 impl Serializable for PrivateKey {
     // x_wing::DECAPSULATION_KEY_SIZE == 32
@@ -35,7 +35,7 @@ impl Serializable for PrivateKey {
         // Check the length is correct and panic if not
         enforce_outbuf_len::<Self>(buf);
 
-        buf.copy_from_slice(self.0.as_bytes());
+        buf.copy_from_slice(&self.0.to_bytes());
     }
 }
 
@@ -57,7 +57,7 @@ impl Deserializable for PrivateKey {
 
 impl ConstantTimeEq for PrivateKey {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.0.as_bytes().ct_eq(other.0.as_bytes())
+        self.0.to_bytes().ct_eq(&other.0.to_bytes())
     }
 }
 
@@ -178,7 +178,10 @@ impl KemTrait for XWing {
             "X-Wing doesn't support authenticated encapsulation. Use Base or Psk operation mode."
         );
 
-        let ss = sk_recip.0.decapsulate(&encapped_key.0);
+        let ss = sk_recip
+            .0
+            .try_decapsulate(&encapped_key.0)
+            .map_err(|_| HpkeError::DecapError)?;
         Ok(SharedSecret(ss))
     }
 


### PR DESCRIPTION
RFC 9180 explicitly rejects it in DHKEM for X25519, so it is very likely that X-Wing as applied to HPKE will also require rejecting it. If the CFRG concrete-hybrid-kems document instead ends up requiring accepting it, then this crate would instead need to support it being configurable (as there are downstream users like age that require rejecting already).

Depends on https://github.com/RustCrypto/KEMs/pull/369.